### PR TITLE
bug: 6 digits and no chars

### DIFF
--- a/src/dto/hourly-apportioned-emissions.params.dto.ts
+++ b/src/dto/hourly-apportioned-emissions.params.dto.ts
@@ -27,7 +27,6 @@ export class HourlyApportionedEmissionsParamsDTO extends PaginationDTO {
 
   @IsOptional()
   @ApiPropertyOptional()
-  @Transform(val => Number.parseFloat(val))
   @Validate(OrisCodeValidation)
   orisCode: number;
 

--- a/src/dto/hourly-apportioned-emissions.params.dto.ts
+++ b/src/dto/hourly-apportioned-emissions.params.dto.ts
@@ -1,7 +1,5 @@
 import { IsOptional, Validate } from 'class-validator';
 import { ApiPropertyOptional } from '@nestjs/swagger';
-import { Transform } from 'class-transformer/decorators';
-
 
 import { PaginationDTO } from './pagination.dto';
 import { ControlTechnology } from '../enums/control-technology.enum';

--- a/src/pipes/oris-code-validation.pipes.ts
+++ b/src/pipes/oris-code-validation.pipes.ts
@@ -6,13 +6,8 @@ import {
 
 @ValidatorConstraint({ name: 'orisCodeValidation' })
 export class OrisCodeValidation implements ValidatorConstraintInterface {
-  validate(orisCode: number, args: ValidationArguments): boolean {
-    return (
-      String(orisCode).length <= 6 &&
-      typeof orisCode === 'number' &&
-      orisCode % 1 === 0 &&
-      orisCode >= 0
-    );
+  validate(orisCode: string, args: ValidationArguments): boolean {
+    return orisCode.length <= 6 && orisCode.match(/^[0-9]+$/) != null;
   }
 
   defaultMessage(args: ValidationArguments) {

--- a/src/pipes/oris-code-validation.pipes.ts
+++ b/src/pipes/oris-code-validation.pipes.ts
@@ -7,7 +7,7 @@ import {
 @ValidatorConstraint({ name: 'orisCodeValidation' })
 export class OrisCodeValidation implements ValidatorConstraintInterface {
   validate(orisCode: string, args: ValidationArguments): boolean {
-    return orisCode.length <= 6 && orisCode.match(/^[0-9]+$/) != null;
+    return orisCode.length <= 6 && orisCode.match(/^[1-9][0-9]+$/) != null;
   }
 
   defaultMessage(args: ValidationArguments) {

--- a/src/pipes/oris-code-validation.pipes.ts
+++ b/src/pipes/oris-code-validation.pipes.ts
@@ -7,7 +7,7 @@ import {
 @ValidatorConstraint({ name: 'orisCodeValidation' })
 export class OrisCodeValidation implements ValidatorConstraintInterface {
   validate(orisCode: string, args: ValidationArguments): boolean {
-    return orisCode.length <= 6 && orisCode.match(/^[1-9][0-9]+$/) != null;
+    return orisCode.length <= 6 && orisCode.match(/^[1-9][0-9]*$/) != null;
   }
 
   defaultMessage(args: ValidationArguments) {


### PR DESCRIPTION
## Pull Request

### Bugs:

- "0000612" was passing even though it was over 6 digits because the preceding 0s were being dropped before validation
- special characters were not beings checked, so something like "2-3" was passing when it shouldn't

### Fixed:

- edited _dto/hourly-apportioned-emissions.params.dto_ so it no longer transforms orisCode to a float
- edited _pipes/oris-code-validation.pipes.ts_ to check for regex so decimals and special characters are invalid

ORIS code format:
positive integer (no negative numbers, not 0)
whole numeric value (no letters or special characters)
no more than 6 digits
no leading 0s (EX: 000670 is invalid, 67000 is valid)
