### PR TITLE
Feature/736 Unit type multi select

### DIFF
--- a/src/dto/hourly-apportioned-emissions.params.dto.ts
+++ b/src/dto/hourly-apportioned-emissions.params.dto.ts
@@ -6,8 +6,8 @@ import { ControlTechnology } from '../enums/control-technology.enum';
 import { UnitFuelType } from '../enums/unit-fuel-type.enum';
 import { UnitType } from '../enums/unit-type.enum';
 import { State } from '../enums/state.enum';
-//import { IsOrisCode } from '../pipes/is-oris-code.pipe';
-import { IsUnitType } from '../pipes/is-unit-type.pipe';
+// import { IsOrisCode } from '../pipes/is-oris-code.pipe';
+// import { IsUnitType } from '../pipes/is-unit-type.pipe';
 import { IsIsoFormat } from '../pipes/is-iso-format.pipe';
 import { IsValidDate } from '../pipes/is-valid-date.pipe';
 import { IsInDateRange } from '../pipes/is-in-date-range.pipe';
@@ -64,11 +64,12 @@ export class HourlyApportionedEmissionsParamsDTO extends PaginationDTO {
   orisCode?: number[];
 
   @IsOptional()
-  @IsUnitType({
-    message:
-      'Unit type is not valid. Refer to the list of available unit types for valid values [placeholder for link to endpoint]',
-  })
-  unitType?: UnitType;
+  // @IsUnitType({
+  //   message:
+  //     'Unit type is not valid. Refer to the list of available unit types for valid values [placeholder for link to endpoint]',
+  // })
+  @Transform((value: string) => value.split(',').map(item => item.trim()))
+  unitType?: UnitType[];
 
   @IsOptional()
   @IsUnitFuelType({

--- a/src/hourly-apportioned-emissions/hour-unit-data.repository.spec.ts
+++ b/src/hourly-apportioned-emissions/hour-unit-data.repository.spec.ts
@@ -49,7 +49,9 @@ describe('HourUnitDataRepository', () => {
 
       // branch coverage
       const emptyFilters: HourlyApportionedEmissionsParamsDTO = new HourlyApportionedEmissionsParamsDTO();
-      let result = await hourUnitDataRepository.getHourlyEmissions(emptyFilters);
+      let result = await hourUnitDataRepository.getHourlyEmissions(
+        emptyFilters,
+      );
 
       const filters: HourlyApportionedEmissionsParamsDTO = {
         page: 1,
@@ -59,7 +61,7 @@ describe('HourUnitDataRepository', () => {
         endDate: new Date(),
         state: [State.TX],
         orisCode: [3],
-        unitType: UnitType.BUBBLING_FLUIDIZED,
+        unitType: [UnitType.BUBBLING_FLUIDIZED],
         unitFuelType: UnitFuelType.COAL,
         controlTechnologies: ControlTechnology.ADDITIVES_TO_ENHANCE,
         opHoursOnly: true,

--- a/src/hourly-apportioned-emissions/hour-unit-data.repository.ts
+++ b/src/hourly-apportioned-emissions/hour-unit-data.repository.ts
@@ -73,7 +73,11 @@ export class HourUnitDataRepository extends Repository<HourUnitData> {
     }
 
     if (unitType) {
-      results.andWhere('uf.unitTypeInfo = :unitType', { unitType: unitType });
+      results.andWhere('UPPER(uf.unitTypeInfo) IN (:...unitType)', {
+        unitType: unitType.map(unit => {
+          return unit.toUpperCase();
+        }),
+      });
     }
 
     if (String(opHoursOnly) === String(true)) {

--- a/src/hourly-apportioned-emissions/hourly-apportioned-emissions.controller.ts
+++ b/src/hourly-apportioned-emissions/hourly-apportioned-emissions.controller.ts
@@ -31,6 +31,7 @@ export class HourlyApportionedEmissionsController {
   })
   @ApiQuery({ name: 'state', required: false, explode: false })
   @ApiQuery({ name: 'orisCode', required: false, explode: false })
+  @ApiQuery({ name: 'unitType', required: false, explode: false })
   getHourlyEmissions(
     @Query()
     hourlyApportionedEmissionsParamsDTO: HourlyApportionedEmissionsParamsDTO,

--- a/src/hourly-apportioned-emissions/hourly-apportioned-emissions.service.spec.ts
+++ b/src/hourly-apportioned-emissions/hourly-apportioned-emissions.service.spec.ts
@@ -30,7 +30,7 @@ let filters: HourlyApportionedEmissionsParamsDTO = {
   endDate: new Date(),
   state: [State.TX],
   orisCode: [3],
-  unitType: UnitType.BUBBLING_FLUIDIZED,
+  unitType: [UnitType.BUBBLING_FLUIDIZED],
   unitFuelType: undefined,
   controlTechnologies: undefined,
   opHoursOnly: false,


### PR DESCRIPTION
## Pull Request

```
Implemented multi select for Unit Type

- updated the paramsDTO so it can accept an array of strings for multiple unitType values
- updated repository query to search for all unitTypes in the provided list and to search once everything is converted to upper case (makes it case insensitive) 
- commented out the isUnitType validation decorator for later use when implementing multi select validation
- updated unit tests to reflect multi select criteria 
- added APIQuery for unitType to controller with explode set to false
```
