### PR TITLE
Feature/789 Allow state whitespaces

### DIFF
--- a/src/dto/hourly-apportioned-emissions.params.dto.ts
+++ b/src/dto/hourly-apportioned-emissions.params.dto.ts
@@ -6,15 +6,12 @@ import { ControlTechnology } from '../enums/control-technology.enum';
 import { UnitFuelType } from '../enums/unit-fuel-type.enum';
 import { UnitType } from '../enums/unit-type.enum';
 import { State } from '../enums/state.enum';
-// import { IsOrisCode } from '../pipes/is-oris-code.pipe';
-// import { IsUnitType } from '../pipes/is-unit-type.pipe';
 import { IsIsoFormat } from '../pipes/is-iso-format.pipe';
 import { IsValidDate } from '../pipes/is-valid-date.pipe';
 import { IsInDateRange } from '../pipes/is-in-date-range.pipe';
 import { IsDateGreaterThanEqualTo } from '../pipes/is-date-greater.pipe';
 import { IsControlTechnology } from '../pipes/is-control-technology.pipe';
 import { IsUnitFuelType } from '../pipes/is-unit-fuel-type.pipe';
-// import { IsStateCode } from '../pipes/is-state-code.pipe';
 
 export class HourlyApportionedEmissionsParamsDTO extends PaginationDTO {
   @IsInDateRange([new Date('1995-01-01'), (new Date())], {

--- a/src/dto/hourly-apportioned-emissions.params.dto.ts
+++ b/src/dto/hourly-apportioned-emissions.params.dto.ts
@@ -51,7 +51,7 @@ export class HourlyApportionedEmissionsParamsDTO extends PaginationDTO {
   //   message:
   //     'The state or territory is not valid. Please enter a valid state or territory using the two letter postal abbreviation (use TX, not Texas).',
   // })
-  @Transform((value: string) => value.split(','))
+  @Transform((value: string) => value.split(',').map(item => item.trim()))
   state?: State[];
 
   @IsOptional()


### PR DESCRIPTION
## Pull Request

```
Altered API to allow whitespaces before or after the delimiter when entering multiple state values

```
