### PR TITLE
feature/1253-quarterly-emissions-validation

### DIFF
--- a/src/dto/apportioned-emissions.params.dto.spec.ts
+++ b/src/dto/apportioned-emissions.params.dto.spec.ts
@@ -13,8 +13,8 @@ import { IsUnitFuelType } from '../pipes/is-unit-fuel-type.pipe';
 import { IsStateCode } from '../pipes/is-state-code.pipe';
 import { IsProgram } from '../pipes/is-program.pipe';
 import { IsYearFormat } from '../pipes/is-year-format.pipe';
-import { IsValidMonthNumber } from '../pipes/is-valid-month-number.pipe';
-import { IsValidMonth } from '../pipes/is-valid-month.pipe';
+import { IsValidNumber } from '../pipes/is-valid-number.pipe';
+import { IsInValidReportingQuarter } from '../pipes/is-in-valid-reporting-quarter.pipe';
 
 describe('-- Apportioned Emissions Params DTO --', () => {
   describe('getHourlyEmissions with query parameters', () => {
@@ -42,24 +42,29 @@ describe('-- Apportioned Emissions Params DTO --', () => {
         this.state = state;
         this.program = program;
       }
-      @IsInDateRange([new Date('1995-01-01'), new Date()], false,true)
+      @IsInDateRange([new Date('1995-01-01'), new Date()], false, true)
       @IsValidDate()
       @IsIsoFormat()
       @IsDefined()
       beginDate: string;
 
       @IsDateGreaterThanEqualTo('beginDate')
-      @IsInDateRange([new Date('1995-01-01'), new Date()], false,true)
+      @IsInDateRange([new Date('1995-01-01'), new Date()], false, true)
       @IsValidDate()
       @IsIsoFormat()
       @IsDefined()
       endDate: string;
 
-      @IsInDateRange([new Date(1995, 0), new Date()], true,true)
+      @IsInDateRange([new Date(1995, 0), new Date()], true, true)
       @IsYearFormat()
       year: string;
 
-      @IsValidMonthNumber()
+      @IsValidNumber(4)
+      @IsInValidReportingQuarter([1, 2, 3], 'year')
+      quarter: string;
+
+      @IsValidNumber(12)
+      @IsInValidReportingQuarter([3, 6, 9], 'year')
       month: string;
 
       @IsOrisCode()

--- a/src/dto/monthly-apportioned-emissions.params.dto.ts
+++ b/src/dto/monthly-apportioned-emissions.params.dto.ts
@@ -3,10 +3,10 @@ import { Transform } from 'class-transformer';
 
 import { ApportionedEmissionsParamsDTO } from './apportioned-emissions.params.dto';
 import { IsInDateRange } from '../pipes/is-in-date-range.pipe';
-import { IsValidMonthNumber } from '../pipes/is-valid-month-number.pipe';
+import { IsValidNumber } from '../pipes/is-valid-number.pipe';
 import { IsYearFormat } from '../pipes/is-year-format.pipe';
 import { ErrorMessages } from '../utils/error-messages';
-import { IsValidMonth } from '../pipes/is-valid-month.pipe';
+import { IsInValidReportingQuarter } from '../pipes/is-in-valid-reporting-quarter.pipe';
 
 export class MonthlyApportionedEmissionsParamsDTO extends ApportionedEmissionsParamsDTO {
   @IsInDateRange([new Date(1995, 0), new Date()], true, true, {
@@ -19,17 +19,17 @@ export class MonthlyApportionedEmissionsParamsDTO extends ApportionedEmissionsPa
   })
   @IsYearFormat({
     each: true,
-    message: ErrorMessages.MultipleFormat('opYear', 'YYYY'),
+    message: ErrorMessages.MultipleFormat('opYear', 'YYYY foramt'),
   })
   @Transform((value: string) => value.split('|').map(item => item.trim()))
   @IsDefined({ message: ErrorMessages.RequiredProperty() })
   opYear: number[];
 
-  @IsValidMonthNumber({
+  @IsValidNumber(12, {
     each: true,
-    message: ErrorMessages.MultipleFormat('opMonth', 'M or MM'),
+    message: ErrorMessages.MultipleFormat('opMonth', 'M or MM format'),
   })
-  @IsValidMonth('opYear', {
+  @IsInValidReportingQuarter([3, 6, 9], 'opYear', {
     each: true,
     message: ErrorMessages.DateRange(
       'opMonth',

--- a/src/dto/monthly-apportioned-emissions.params.dto.ts
+++ b/src/dto/monthly-apportioned-emissions.params.dto.ts
@@ -2,27 +2,14 @@ import { IsDefined } from 'class-validator';
 import { Transform } from 'class-transformer';
 
 import { ApportionedEmissionsParamsDTO } from './apportioned-emissions.params.dto';
-import { IsInDateRange } from '../pipes/is-in-date-range.pipe';
 import { IsValidNumber } from '../pipes/is-valid-number.pipe';
-import { IsYearFormat } from '../pipes/is-year-format.pipe';
 import { ErrorMessages } from '../utils/error-messages';
 import { IsInValidReportingQuarter } from '../pipes/is-in-valid-reporting-quarter.pipe';
+import { OpYear } from '../utils/validator.const';
 
 export class MonthlyApportionedEmissionsParamsDTO extends ApportionedEmissionsParamsDTO {
-  @IsInDateRange([new Date(1995, 0), new Date()], true, true, {
-    each: true,
-    message: ErrorMessages.DateRange(
-      'opYear',
-      true,
-      'a year between 1995 and this year',
-    ),
-  })
-  @IsYearFormat({
-    each: true,
-    message: ErrorMessages.MultipleFormat('opYear', 'YYYY foramt'),
-  })
+  @OpYear()
   @Transform((value: string) => value.split('|').map(item => item.trim()))
-  @IsDefined({ message: ErrorMessages.RequiredProperty() })
   opYear: number[];
 
   @IsValidNumber(12, {

--- a/src/dto/quarterly-apportioned-emissions.params.dto.ts
+++ b/src/dto/quarterly-apportioned-emissions.params.dto.ts
@@ -3,26 +3,13 @@ import { Transform } from 'class-transformer';
 
 import { ApportionedEmissionsParamsDTO } from './apportioned-emissions.params.dto';
 import { ErrorMessages } from '../utils/error-messages';
-import { IsYearFormat } from '../pipes/is-year-format.pipe';
-import { IsInDateRange } from '../pipes/is-in-date-range.pipe';
 import { IsValidNumber } from '../pipes/is-valid-number.pipe';
 import { IsInValidReportingQuarter } from '../pipes/is-in-valid-reporting-quarter.pipe';
+import { OpYear } from '../utils/validator.const';
 
 export class QuarterlyApportionedEmissionsParamsDTO extends ApportionedEmissionsParamsDTO {
-  @IsInDateRange([new Date(1995, 0), new Date()], true, true, {
-    each: true,
-    message: ErrorMessages.DateRange(
-      'opYear',
-      true,
-      'a year between 1995 and this year',
-    ),
-  })
-  @IsYearFormat({
-    each: true,
-    message: ErrorMessages.MultipleFormat('opYear', 'YYYY format'),
-  })
+  @OpYear()
   @Transform((value: string) => value.split('|').map(item => item.trim()))
-  @IsDefined({ message: ErrorMessages.RequiredProperty() })
   opYear: number[];
 
   @IsValidNumber(4, {

--- a/src/dto/quarterly-apportioned-emissions.params.dto.ts
+++ b/src/dto/quarterly-apportioned-emissions.params.dto.ts
@@ -2,13 +2,45 @@ import { IsDefined } from 'class-validator';
 import { Transform } from 'class-transformer';
 
 import { ApportionedEmissionsParamsDTO } from './apportioned-emissions.params.dto';
+import { ErrorMessages } from '../utils/error-messages';
+import { IsYearFormat } from '../pipes/is-year-format.pipe';
+import { IsInDateRange } from '../pipes/is-in-date-range.pipe';
+import { IsValidNumber } from '../pipes/is-valid-number.pipe';
+import { IsInValidReportingQuarter } from '../pipes/is-in-valid-reporting-quarter.pipe';
 
 export class QuarterlyApportionedEmissionsParamsDTO extends ApportionedEmissionsParamsDTO {
+  @IsInDateRange([new Date(1995, 0), new Date()], true, true, {
+    each: true,
+    message: ErrorMessages.DateRange(
+      'opYear',
+      true,
+      'a year between 1995 and this year',
+    ),
+  })
+  @IsYearFormat({
+    each: true,
+    message: ErrorMessages.MultipleFormat('opYear', 'YYYY format'),
+  })
   @Transform((value: string) => value.split('|').map(item => item.trim()))
-  @IsDefined()
+  @IsDefined({ message: ErrorMessages.RequiredProperty() })
   opYear: number[];
 
+  @IsValidNumber(4, {
+    each: true,
+    message: ErrorMessages.MultipleFormat(
+      'opQuarter',
+      'single digit format (ex.1,2,3,4)',
+    ),
+  })
+  @IsInValidReportingQuarter([1, 2, 3], 'opYear', {
+    each: true,
+    message: ErrorMessages.DateRange(
+      'opQuarter',
+      true,
+      `a quarter between 01/01/1995 and the end of the calendar quarter, ${ErrorMessages.ReportingQuarter()}`,
+    ),
+  })
   @Transform((value: string) => value.split('|').map(item => item.trim()))
-  @IsDefined()
+  @IsDefined({ message: ErrorMessages.RequiredProperty() })
   opQuarter: number[];
 }

--- a/src/pipes/is-in-valid-reporting-quarter.pipe.ts
+++ b/src/pipes/is-in-valid-reporting-quarter.pipe.ts
@@ -4,13 +4,14 @@ import {
   ValidationArguments,
 } from 'class-validator';
 
-export function IsValidMonth(
+export function IsInValidReportingQuarter(
+  values = [],
   property: string,
   validationOptions?: ValidationOptions,
 ) {
   return function(object: Object, propertyName: string) {
     registerDecorator({
-      name: 'IsValidMonth',
+      name: 'IsInValidReportingQuarter',
       target: object.constructor,
       propertyName: propertyName,
       constraints: [property],
@@ -22,20 +23,26 @@ export function IsValidMonth(
           const curDate = new Date();
           const curYear = new Date().getFullYear();
           const yearIndicator =
-            relatedValue.includes(curYear.toString()) &&
-            relatedValue.length === 1;
-          if (curDate < new Date(`June 30, ${curYear}`) && yearIndicator) {
-            return (value as number) <= 3;
+            relatedValue?.includes(curYear.toString()) &&
+            relatedValue?.length === 1;
+
+          if (curDate < new Date(`March 31, ${curYear}`) && yearIndicator) {
+            return false;
+          } else if (
+            curDate < new Date(`June 30, ${curYear}`) &&
+            yearIndicator
+          ) {
+            return (value as number) <= values[0];
           } else if (
             curDate < new Date(`September 30, ${curYear}`) &&
             yearIndicator
           ) {
-            return (value as number) <= 6;
+            return (value as number) <= values[1];
           } else if (
             curDate < new Date(`December 31, ${curYear}`) &&
             yearIndicator
           ) {
-            return (value as number) <= 9;
+            return (value as number) <= values[2];
           }
           return true;
         },

--- a/src/pipes/is-in-valid-reporting-quarter.pipe.ts
+++ b/src/pipes/is-in-valid-reporting-quarter.pipe.ts
@@ -5,7 +5,7 @@ import {
 } from 'class-validator';
 
 export function IsInValidReportingQuarter(
-  values = [],
+  values: number[],
   property: string,
   validationOptions?: ValidationOptions,
 ) {

--- a/src/pipes/is-valid-number.pipe.ts
+++ b/src/pipes/is-valid-number.pipe.ts
@@ -5,10 +5,13 @@ import {
   isNumberString,
 } from 'class-validator';
 
-export function IsValidMonthNumber(validationOptions?: ValidationOptions) {
+export function IsValidNumber(
+  maxNumber: number,
+  validationOptions?: ValidationOptions,
+) {
   return function(object: Object, propertyName: string) {
     registerDecorator({
-      name: 'IsValidMonthNumber',
+      name: 'IsValidNumber',
       target: object.constructor,
       propertyName: propertyName,
       options: validationOptions,
@@ -18,7 +21,7 @@ export function IsValidMonthNumber(validationOptions?: ValidationOptions) {
             return (
               isNumberString(value, { no_symbols: true }) &&
               (value as number) > 0 &&
-              (value as number) <= 12
+              (value as number) <= maxNumber
             );
           }
           return true;

--- a/src/utils/error-messages.ts
+++ b/src/utils/error-messages.ts
@@ -28,11 +28,11 @@ export class ErrorMessages {
   }
 
   public static MultipleFormat(parameter: string, format: string) {
-    return `One or more ${parameter}s are not in the ${format} format. Ensure all ${parameter}s are in the ${format} format`;
+    return `One or more ${parameter}s are not in the ${format}. Ensure all ${parameter}s are in the ${format}`;
   }
 
   public static SingleFormat(parameter: string, format: string) {
-    return `Ensure that ${parameter} is in the ${format} format.`;
+    return `Ensure that ${parameter} is in the ${format}.`;
   }
 
   public static BeginEndDate(constraint: string) {

--- a/src/utils/validator.const.ts
+++ b/src/utils/validator.const.ts
@@ -6,6 +6,7 @@ import { IsValidDate } from '../pipes/is-valid-date.pipe';
 import { IsIsoFormat } from '../pipes/is-iso-format.pipe';
 import { IsDateGreaterThanEqualTo } from '../pipes/is-date-greater.pipe';
 import { ErrorMessages } from './error-messages';
+import { IsYearFormat } from '../pipes/is-year-format.pipe';
 
 export function BeginDate() {
   return applyDecorators(
@@ -45,6 +46,24 @@ export function EndDate() {
     }),
     IsIsoFormat({
       message: ErrorMessages.SingleFormat('endDate', 'YYYY-MM-DD format'),
+    }),
+    IsDefined({ message: ErrorMessages.RequiredProperty() }),
+  );
+}
+
+export function OpYear() {
+  return applyDecorators(
+    IsInDateRange([new Date(1995, 0), new Date()], true, true, {
+      each: true,
+      message: ErrorMessages.DateRange(
+        'opYear',
+        true,
+        'a year between 1995 and this year',
+      ),
+    }),
+    IsYearFormat({
+      each: true,
+      message: ErrorMessages.MultipleFormat('opYear', 'YYYY format'),
     }),
     IsDefined({ message: ErrorMessages.RequiredProperty() }),
   );

--- a/src/utils/validator.const.ts
+++ b/src/utils/validator.const.ts
@@ -20,7 +20,7 @@ export function BeginDate() {
       message: ErrorMessages.DateValidity(),
     }),
     IsIsoFormat({
-      message: ErrorMessages.SingleFormat('beginDate', 'YYYY-MM-DD'),
+      message: ErrorMessages.SingleFormat('beginDate', 'YYYY-MM-DD format'),
     }),
     IsDefined({
       message: ErrorMessages.RequiredProperty(),
@@ -44,7 +44,7 @@ export function EndDate() {
       message: ErrorMessages.DateValidity(),
     }),
     IsIsoFormat({
-      message: ErrorMessages.SingleFormat('endDate', 'YYYY-MM-DD'),
+      message: ErrorMessages.SingleFormat('endDate', 'YYYY-MM-DD format'),
     }),
     IsDefined({ message: ErrorMessages.RequiredProperty() }),
   );


### PR DESCRIPTION
## Pull Request

```
- Modify existing pipes to make it more generic - IsValidNumber, IsInValidReportingQuarter
- Modify monthly apportioned emissions params dto with new pipes
- Add validation pipes to quarterly apportioned emissions params dto
- Modify format error messages to allow text after the word format (necessary for quarterly emissions error message)
- Modify validator.const.ts with new format error message
- Added opYear function to validator.const file due to duplicated code
- Modify unit tests
```
