### PR TITLE
bug/2715 MATS DATA API Endpoint CSV label

### DIFF
--- a/src/constants/field-mappings.ts
+++ b/src/constants/field-mappings.ts
@@ -123,7 +123,7 @@ hourlyMats.push(
   { ...propertyMetadata.hfMass.fieldLabels },
   { ...propertyMetadata.hfMassMeasureFlg.fieldLabels },
   { ...propertyMetadata.associatedStacks.fieldLabels },
-  { ...propertyMetadata.steamLoad.fieldLabels },
+  { ...propertyMetadata.steamLoadHourly.fieldLabels },
   ...unitCharacteristics,
   { ...propertyMetadata.so2ControlInfo.fieldLabels },
   { ...propertyMetadata.noxControlInfo.fieldLabels },

--- a/src/dto/hourly-mats-apportioned-emissions.dto.ts
+++ b/src/dto/hourly-mats-apportioned-emissions.dto.ts
@@ -124,9 +124,9 @@ export class HourlyMatsApportionedEmissionsDTO extends UnitFactDTO {
   hfMassMeasureFlg: string;
 
   @ApiProperty({
-    description: propertyMetadata.steamLoad.description,
-    example: propertyMetadata.steamLoad.example,
-    name: propertyMetadata.steamLoad.fieldLabels.value,
+    description: propertyMetadata.steamLoadHourly.description,
+    example: propertyMetadata.steamLoadHourly.example,
+    name: propertyMetadata.steamLoadHourly.fieldLabels.value,
   })
   steamLoad?: number;
 }

--- a/src/utils/validator.const.ts
+++ b/src/utils/validator.const.ts
@@ -1,5 +1,5 @@
 import { applyDecorators } from '@nestjs/common';
-import { IsDefined, IsNotEmpty } from 'class-validator';
+import { IsDefined } from 'class-validator';
 import { ErrorMessages } from '@us-epa-camd/easey-common/constants';
 import {
   IsInDateRange,
@@ -36,9 +36,6 @@ export function BeginDate(isMats = false) {
     IsDefined({
       message: ErrorMessages.RequiredProperty(),
     }),
-    IsNotEmpty({
-      message: ErrorMessages.RequiredProperty(),
-    })
   );
 }
 
@@ -70,9 +67,6 @@ export function EndDate(isMats = false) {
       message: ErrorMessages.SingleFormat('endDate', 'YYYY-MM-DD format'),
     }),
     IsDefined({ message: ErrorMessages.RequiredProperty() }),
-    IsNotEmpty({
-      message: ErrorMessages.RequiredProperty(),
-    })
   );
 }
 


### PR DESCRIPTION
## Pull Request

```

- Fix steamLoad csv label to Steam Load (1000 lb/hr)
- remove isNotEmpty() validation from begin and end date to get rid of two null error messages

```
