### PR TITLE
Feature/2771 Create Hourly Emissions National Aggregation Endpoints

### DIFF
--- a/src/apportioned-emissions/hourly/hour-unit-data.repository.spec.ts
+++ b/src/apportioned-emissions/hourly/hour-unit-data.repository.spec.ts
@@ -257,4 +257,43 @@ describe('HourUnitDataRepository', () => {
       expect(paginatedResult).toEqual('mockRawEmissions');
     });
   });
+
+  describe('getEmissionsNationalAggregation', () => {
+    it('calls createQueryBuilder and gets all HourUnitData aggregated nationally from the repository no filters', async () => {
+      const result = await repository.getEmissionsNationalAggregation(
+        req,
+        new PaginatedHourlyApportionedEmissionsParamsDTO(),
+      );
+
+      expect(queryBuilder.getRawMany).toHaveBeenCalled();
+      expect(result).toEqual('mockRawEmissions');
+    });
+
+    it('calls createQueryBuilder and gets HourUnitData aggregated nationally from the repository with filters', async () => {
+      const result = await repository.getEmissionsNationalAggregation(
+        req,
+        filters,
+      );
+      expect(queryBuilder.getRawMany).toHaveBeenCalled();
+      expect(result).toEqual('mockRawEmissions');
+    });
+
+    it('calls createQueryBuilder and gets all HourUnitData aggregated nationally from the repository with pagination', async () => {
+      ResponseHeaders.setPagination = jest
+        .fn()
+        .mockReturnValue('paginated results');
+
+      let paginatedFilters = filters;
+      paginatedFilters.page = 1;
+      paginatedFilters.perPage = 10;
+
+      const paginatedResult = await repository.getEmissionsNationalAggregation(
+        req,
+        paginatedFilters,
+      );
+
+      expect(ResponseHeaders.setPagination).toHaveBeenCalled();
+      expect(paginatedResult).toEqual('mockRawEmissions');
+    });
+  });
 });

--- a/src/apportioned-emissions/hourly/hourly-apportioned-emissions.controller.spec.ts
+++ b/src/apportioned-emissions/hourly/hourly-apportioned-emissions.controller.spec.ts
@@ -11,9 +11,8 @@ import {
   HourlyApportionedEmissionsParamsDTO,
   PaginatedHourlyApportionedEmissionsParamsDTO,
 } from '../../dto/hourly-apportioned-emissions.params.dto';
-import { HourlyApportionedEmissionsFacilityAggregationDTO } from '../../dto/hourly-apportioned-emissions-facility-aggregation.dto';
-import { HourlyApportionedEmissionsStateAggregationDTO } from '../../dto/hourly-apportioned-emissions-state-aggregation.dto';
 import { StreamModule } from '@us-epa-camd/easey-common/stream';
+import { HourlyApportionedEmissionsNationalAggregationDTO } from '../../dto/hourly-apportioned-emissions-national-aggregation.dto';
 
 const mockRequest = (url: string) => {
   return {

--- a/src/apportioned-emissions/hourly/hourly-apportioned-emissions.controller.ts
+++ b/src/apportioned-emissions/hourly/hourly-apportioned-emissions.controller.ts
@@ -38,6 +38,7 @@ import {
   StreamHourlyApportionedEmissionsParamsDTO,
 } from '../../dto/hourly-apportioned-emissions.params.dto';
 import { HourlyApportionedEmissionsStateAggregationDTO } from '../../dto/hourly-apportioned-emissions-state-aggregation.dto';
+import { HourlyApportionedEmissionsNationalAggregationDTO } from '../../dto/hourly-apportioned-emissions-national-aggregation.dto';
 
 @Controller()
 @ApiSecurity('APIKey')
@@ -45,6 +46,7 @@ import { HourlyApportionedEmissionsStateAggregationDTO } from '../../dto/hourly-
 @ApiExtraModels(HourlyApportionedEmissionsDTO)
 @ApiExtraModels(HourlyApportionedEmissionsFacilityAggregationDTO)
 @ApiExtraModels(HourlyApportionedEmissionsStateAggregationDTO)
+@ApiExtraModels(HourlyApportionedEmissionsNationalAggregationDTO)
 export class HourlyApportionedEmissionsController {
   constructor(private readonly service: HourlyApportionedEmissionsService) {}
 
@@ -60,7 +62,7 @@ export class HourlyApportionedEmissionsController {
       'text/csv': {
         schema: {
           type: 'string',
-          example: fieldMappings.emissions.hourly.unit
+          example: fieldMappings.emissions.hourly.aggregation.unit
             .map(i => i.label)
             .join(','),
         },
@@ -91,7 +93,7 @@ export class HourlyApportionedEmissionsController {
       'text/csv': {
         schema: {
           type: 'string',
-          example: fieldMappings.emissions.hourly.unit
+          example: fieldMappings.emissions.hourly.aggregation.unit
             .map(i => i.label)
             .join(','),
         },
@@ -128,7 +130,7 @@ export class HourlyApportionedEmissionsController {
       'text/csv': {
         schema: {
           type: 'string',
-          example: fieldMappings.emissions.hourly.facility
+          example: fieldMappings.emissions.hourly.aggregation.facility
             .map(i => i.label)
             .join(','),
         },
@@ -160,7 +162,7 @@ export class HourlyApportionedEmissionsController {
       'text/csv': {
         schema: {
           type: 'string',
-          example: fieldMappings.emissions.hourly.facility
+          example: fieldMappings.emissions.hourly.aggregation.facility
             .map(i => i.label)
             .join(','),
         },
@@ -191,7 +193,7 @@ export class HourlyApportionedEmissionsController {
       'text/csv': {
         schema: {
           type: 'string',
-          example: fieldMappings.emissions.hourly.state
+          example: fieldMappings.emissions.hourly.aggregation.state
             .map(i => i.label)
             .join(','),
         },
@@ -223,7 +225,7 @@ export class HourlyApportionedEmissionsController {
       'text/csv': {
         schema: {
           type: 'string',
-          example: fieldMappings.emissions.hourly.state
+          example: fieldMappings.emissions.hourly.aggregation.state
             .map(i => i.label)
             .join(','),
         },
@@ -239,5 +241,68 @@ export class HourlyApportionedEmissionsController {
     @Query() params: HourlyApportionedEmissionsParamsDTO,
   ): Promise<StreamableFile> {
     return this.service.streamEmissionsStateAggregation(req, params);
+  }
+
+  @Get('national')
+  @ApiOkResponse({
+    description:
+      'Retrieves Hourly Apportioned Emissions National Aggregation data per filter criteria',
+    content: {
+      'application/json': {
+        schema: {
+          $ref: getSchemaPath(HourlyApportionedEmissionsNationalAggregationDTO),
+        },
+      },
+      'text/csv': {
+        schema: {
+          type: 'string',
+          example: fieldMappings.emissions.hourly.aggregation.national
+            .map(i => i.label)
+            .join(','),
+        },
+      },
+    },
+  })
+  @BadRequestResponse()
+  @NotFoundResponse()
+  @ApiQueryMultiSelect()
+  @ApiProgramQuery()
+  @UseInterceptors(Json2CsvInterceptor)
+  getEmissionsNationalAggregation(
+    @Req() req: Request,
+    @Query() params: PaginatedHourlyApportionedEmissionsParamsDTO,
+  ): Promise<HourlyApportionedEmissionsNationalAggregationDTO[]> {
+    return this.service.getEmissionsNationalAggregation(req, params);
+  }
+
+  @Get('national/stream')
+  @ApiOkResponse({
+    description:
+      'Streams Hourly Apportioned Emissions National Aggregation data per filter criteria',
+    content: {
+      'application/json': {
+        schema: {
+          $ref: getSchemaPath(HourlyApportionedEmissionsNationalAggregationDTO),
+        },
+      },
+      'text/csv': {
+        schema: {
+          type: 'string',
+          example: fieldMappings.emissions.hourly.aggregation.national
+            .map(i => i.label)
+            .join(','),
+        },
+      },
+    },
+  })
+  @BadRequestResponse()
+  @NotFoundResponse()
+  @ApiQueryMultiSelect()
+  @ApiProgramQuery()
+  streamEmissionsNationalAggregation(
+    @Req() req: Request,
+    @Query() params: HourlyApportionedEmissionsParamsDTO,
+  ): Promise<StreamableFile> {
+    return this.service.streamEmissionsNationalAggregation(req, params);
   }
 }

--- a/src/apportioned-emissions/hourly/hourly-apportioned-emissions.service.spec.ts
+++ b/src/apportioned-emissions/hourly/hourly-apportioned-emissions.service.spec.ts
@@ -19,10 +19,12 @@ jest.mock('uuid', () => {
 
 const mockRepository = () => ({
   getEmissions: jest.fn(),
+  getEmissionsNationalAggregation: jest.fn(),
   streamEmissions: jest.fn(),
   getEmissionsFacilityAggregation: jest.fn(),
   streamEmissionsFacilityAggregationy: jest.fn(),
   getStreamQuery: jest.fn(),
+  getNationalStreamQuery: jest.fn(),
 });
 
 const mockRequest = () => {
@@ -99,6 +101,28 @@ describe('-- Hourly Apportioned Emissions Service --', () => {
         new StreamableFile(Buffer.from('stream'), {
           type: req.headers.accept,
           disposition: `attachment; filename="hourly-emissions-${0}.json"`,
+        }),
+      );
+    });
+  });
+
+  describe('streamEmissionsNationalAggregation', () => {
+    it('calls HourlyUnitDataRepository.getNationalStreamQuery() and streams all emissions nationally aggregated from the repository', async () => {
+      repository.getStreamQuery.mockResolvedValue('');
+
+      let filters = new HourlyApportionedEmissionsParamsDTO();
+
+      req.headers.accept = '';
+
+      let result = await service.streamEmissionsNationalAggregation(
+        req,
+        filters,
+      );
+
+      expect(result).toEqual(
+        new StreamableFile(Buffer.from('stream'), {
+          type: req.headers.accept,
+          disposition: `attachment; filename="hourly-emissions-national-aggregation${0}.json"`,
         }),
       );
     });

--- a/src/constants/field-mappings.ts
+++ b/src/constants/field-mappings.ts
@@ -3,6 +3,7 @@ import { propertyMetadata } from '@us-epa-camd/easey-common/constants';
 const hourly = [];
 const hourlyFacilityAggregation = [];
 const hourlyStateAggregation = [];
+const hourlyNationalAggregation = [];
 const daily = [];
 const monthly = [];
 const quarterly = [];
@@ -51,6 +52,8 @@ const hourlyCharacteristics = [
 ];
 
 const hourlyAggregationData = [
+  { ...propertyMetadata.date.fieldLabels },
+  { ...propertyMetadata.hour.fieldLabels },
   { ...propertyMetadata.grossLoadHourly.fieldLabels },
   { ...propertyMetadata.steamLoadHourly.fieldLabels },
   { ...propertyMetadata.so2MassHourly.fieldLabels },
@@ -86,17 +89,15 @@ hourlyFacilityAggregation.push(
   { ...propertyMetadata.stateCode.fieldLabels },
   { ...propertyMetadata.facilityName.fieldLabels },
   { ...propertyMetadata.facilityId.fieldLabels },
-  { ...propertyMetadata.date.fieldLabels },
-  { ...propertyMetadata.hour.fieldLabels },
   ...hourlyAggregationData,
 );
 
 hourlyStateAggregation.push(
   { ...propertyMetadata.stateCode.fieldLabels },
-  { ...propertyMetadata.date.fieldLabels },
-  { ...propertyMetadata.hour.fieldLabels },
   ...hourlyAggregationData,
 );
+
+hourlyNationalAggregation.push(...hourlyAggregationData);
 
 daily.push(
   ...commonCharacteristics,
@@ -161,9 +162,12 @@ hourlyMats.push(
 export const fieldMappings = {
   emissions: {
     hourly: {
-      unit: hourly,
-      facility: hourlyFacilityAggregation,
-      state: hourlyStateAggregation,
+      aggregation: {
+        unit: hourly,
+        facility: hourlyFacilityAggregation,
+        state: hourlyStateAggregation,
+        national: hourlyNationalAggregation,
+      },
     },
     daily: daily,
     monthly: monthly,

--- a/src/dto/hourly-apportioned-emissions-aggregation.dto.ts
+++ b/src/dto/hourly-apportioned-emissions-aggregation.dto.ts
@@ -1,0 +1,22 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { propertyMetadata } from '@us-epa-camd/easey-common/constants';
+import { ApportionedEmissionsAggregationDTO } from './apportioned-emissions-aggregation.dto';
+
+export class HourlyApportionedEmissionsAggregationDTO extends ApportionedEmissionsAggregationDTO {
+  constructor() {
+    super();
+  }
+  @ApiProperty({
+    description: propertyMetadata.date.description,
+    example: propertyMetadata.date.example,
+    name: propertyMetadata.date.fieldLabels.value,
+  })
+  date: string;
+
+  @ApiProperty({
+    description: propertyMetadata.hour.description,
+    example: propertyMetadata.hour.example,
+    name: propertyMetadata.hour.fieldLabels.value,
+  })
+  hour: number;
+}

--- a/src/dto/hourly-apportioned-emissions-facility-aggregation.dto.ts
+++ b/src/dto/hourly-apportioned-emissions-facility-aggregation.dto.ts
@@ -1,8 +1,8 @@
 import { ApiProperty } from '@nestjs/swagger';
 import { propertyMetadata } from '@us-epa-camd/easey-common/constants';
-import { ApportionedEmissionsAggregationDTO } from './apportioned-emissions-aggregation.dto';
+import { HourlyApportionedEmissionsAggregationDTO } from './hourly-apportioned-emissions-aggregation.dto';
 
-export class HourlyApportionedEmissionsFacilityAggregationDTO extends ApportionedEmissionsAggregationDTO {
+export class HourlyApportionedEmissionsFacilityAggregationDTO extends HourlyApportionedEmissionsAggregationDTO {
   constructor() {
     super();
   }
@@ -26,18 +26,4 @@ export class HourlyApportionedEmissionsFacilityAggregationDTO extends Apportione
     name: propertyMetadata.facilityId.fieldLabels.value,
   })
   facilityId?: number;
-
-  @ApiProperty({
-    description: propertyMetadata.date.description,
-    example: propertyMetadata.date.example,
-    name: propertyMetadata.date.fieldLabels.value,
-  })
-  date: string;
-
-  @ApiProperty({
-    description: propertyMetadata.hour.description,
-    example: propertyMetadata.hour.example,
-    name: propertyMetadata.hour.fieldLabels.value,
-  })
-  hour: number;
 }

--- a/src/dto/hourly-apportioned-emissions-national-aggregation.dto.ts
+++ b/src/dto/hourly-apportioned-emissions-national-aggregation.dto.ts
@@ -1,0 +1,7 @@
+import { HourlyApportionedEmissionsAggregationDTO } from './hourly-apportioned-emissions-aggregation.dto';
+
+export class HourlyApportionedEmissionsNationalAggregationDTO extends HourlyApportionedEmissionsAggregationDTO {
+  constructor() {
+    super();
+  }
+}

--- a/src/dto/hourly-apportioned-emissions-state-aggregation.dto.ts
+++ b/src/dto/hourly-apportioned-emissions-state-aggregation.dto.ts
@@ -1,8 +1,8 @@
 import { ApiProperty } from '@nestjs/swagger';
 import { propertyMetadata } from '@us-epa-camd/easey-common/constants';
-import { ApportionedEmissionsAggregationDTO } from './apportioned-emissions-aggregation.dto';
+import { HourlyApportionedEmissionsAggregationDTO } from './hourly-apportioned-emissions-aggregation.dto';
 
-export class HourlyApportionedEmissionsStateAggregationDTO extends ApportionedEmissionsAggregationDTO {
+export class HourlyApportionedEmissionsStateAggregationDTO extends HourlyApportionedEmissionsAggregationDTO {
   constructor() {
     super();
   }
@@ -12,18 +12,4 @@ export class HourlyApportionedEmissionsStateAggregationDTO extends ApportionedEm
     name: propertyMetadata.stateCode.fieldLabels.value,
   })
   stateCode: string;
-
-  @ApiProperty({
-    description: propertyMetadata.date.description,
-    example: propertyMetadata.date.example,
-    name: propertyMetadata.date.fieldLabels.value,
-  })
-  date: string;
-
-  @ApiProperty({
-    description: propertyMetadata.hour.description,
-    example: propertyMetadata.hour.example,
-    name: propertyMetadata.hour.fieldLabels.value,
-  })
-  hour: number;
 }

--- a/src/dto/hourly-apportioned-emissions.params.dto.ts
+++ b/src/dto/hourly-apportioned-emissions.params.dto.ts
@@ -57,7 +57,7 @@ export class StreamHourlyApportionedEmissionsParamsDTO extends HourlyApportioned
     each: true,
     message: ErrorMessages.RemovableParameter(),
   })
-  @IsInResponse(fieldMappings.emissions.hourly.unit, {
+  @IsInResponse(fieldMappings.emissions.hourly.aggregation.unit, {
     each: true,
     message: ErrorMessages.ValidParameter(),
   })


### PR DESCRIPTION
## Pull Request

```
- create HourlyApportionedEmissionsAggregationDTO
- modify field mappings 
- add hourlyApportionedEmissionsNationalAggregationDTO
- add createNationalAggregationQuery, getEmissionsNationalAggregation, getNationalStreamQuery functions in repo
- add national and national/stream endpoints in the controller
- add getEmissionsNationalAggregation() and streamEmissionsNationalAggregation() to service
- add unit tests


```
