### PR TITLE
Feature/2779 Create Monthly Emissions State Aggregation Endpoints

### DIFF
--- a/src/apportioned-emissions/monthly/month-unit-data.repository.spec.ts
+++ b/src/apportioned-emissions/monthly/month-unit-data.repository.spec.ts
@@ -211,4 +211,43 @@ describe('MonthUnitDataRepository', () => {
       expect(paginatedResult).toEqual('mockRawEmissions');
     });
   });
+
+  describe('getEmissionsStateAggregation', () => {
+    it('calls createQueryBuilder and gets all MonthUnitData aggregated by state from the repository with no filters', async () => {
+      const result = await repository.getEmissionsStateAggregation(
+        req,
+        new PaginatedMonthlyApportionedEmissionsParamsDTO(),
+      );
+
+      expect(queryBuilder.getRawMany).toHaveBeenCalled();
+      expect(result).toEqual('mockRawEmissions');
+    });
+
+    it('calls createQueryBuilder and gets MonthUnitData aggregated by state from the repository with filters', async () => {
+      const result = await repository.getEmissionsStateAggregation(
+        req,
+        filters,
+      );
+      expect(queryBuilder.getRawMany).toHaveBeenCalled();
+      expect(result).toEqual('mockRawEmissions');
+    });
+
+    it('calls createQueryBuilder and gets all MonthUnitData aggregated by state from the repository with pagination', async () => {
+      ResponseHeaders.setPagination = jest
+        .fn()
+        .mockReturnValue('paginated results');
+
+      let paginatedFilters = filters;
+      paginatedFilters.page = 1;
+      paginatedFilters.perPage = 10;
+
+      const paginatedResult = await repository.getEmissionsStateAggregation(
+        req,
+        paginatedFilters,
+      );
+
+      expect(ResponseHeaders.setPagination).toHaveBeenCalled();
+      expect(paginatedResult).toEqual('mockRawEmissions');
+    });
+  });
 });

--- a/src/apportioned-emissions/monthly/monthly-apportioned-emissions.controller.ts
+++ b/src/apportioned-emissions/monthly/monthly-apportioned-emissions.controller.ts
@@ -37,12 +37,14 @@ import {
   StreamMonthlyApportionedEmissionsParamsDTO,
 } from '../../dto/monthly-apportioned-emissions.params.dto';
 import { MonthlyApportionedEmissionsFacilityAggregationDTO } from '../../dto/monthly-apportioned-emissions-facility-aggregation.dto';
+import { MonthlyApportionedEmissionsStateAggregationDTO } from '../../dto/monthly-apportioned-emissions-state-aggregation.dto';
 
 @Controller()
 @ApiSecurity('APIKey')
 @ApiTags('Apportioned Monthly Emissions')
 @ApiExtraModels(MonthlyApportionedEmissionsDTO)
 @ApiExtraModels(MonthlyApportionedEmissionsFacilityAggregationDTO)
+@ApiExtraModels(MonthlyApportionedEmissionsStateAggregationDTO)
 export class MonthlyApportionedEmissionsController {
   constructor(private readonly service: MonthlyApportionedEmissionsService) {}
 
@@ -175,5 +177,70 @@ export class MonthlyApportionedEmissionsController {
     @Query() params: MonthlyApportionedEmissionsParamsDTO,
   ): Promise<StreamableFile> {
     return this.service.streamEmissionsFacilityAggregation(req, params);
+  }
+
+  @Get('state')
+  @ApiOkResponse({
+    description:
+      'Retrieves Monthly Apportioned Emissions State Aggregation data per filter criteria',
+    content: {
+      'application/json': {
+        schema: {
+          $ref: getSchemaPath(MonthlyApportionedEmissionsStateAggregationDTO),
+        },
+      },
+      'text/csv': {
+        schema: {
+          type: 'string',
+          example: fieldMappings.emissions.monthly.data.aggregation.state
+            .map(i => i.label)
+            .join(','),
+        },
+      },
+    },
+  })
+  @BadRequestResponse()
+  @NotFoundResponse()
+  @ApiQueryMultiSelect()
+  @ApiQueryMonthly()
+  @ApiProgramQuery()
+  @UseInterceptors(Json2CsvInterceptor)
+  getEmissionsStateAggregation(
+    @Req() req: Request,
+    @Query() params: PaginatedMonthlyApportionedEmissionsParamsDTO,
+  ): Promise<MonthlyApportionedEmissionsStateAggregationDTO[]> {
+    return this.service.getEmissionsStateAggregation(req, params);
+  }
+
+  @Get('state/stream')
+  @ApiOkResponse({
+    description:
+      'Streams Monthly Apportioned Emissions State Aggregation data per filter criteria',
+    content: {
+      'application/json': {
+        schema: {
+          $ref: getSchemaPath(MonthlyApportionedEmissionsStateAggregationDTO),
+        },
+      },
+      'text/csv': {
+        schema: {
+          type: 'string',
+          example: fieldMappings.emissions.monthly.data.aggregation.state
+            .map(i => i.label)
+            .join(','),
+        },
+      },
+    },
+  })
+  @BadRequestResponse()
+  @NotFoundResponse()
+  @ApiQueryMultiSelect()
+  @ApiQueryMonthly()
+  @ApiProgramQuery()
+  streamEmissionsStateAggregation(
+    @Req() req: Request,
+    @Query() params: MonthlyApportionedEmissionsParamsDTO,
+  ): Promise<StreamableFile> {
+    return this.service.streamEmissionsStateAggregation(req, params);
   }
 }

--- a/src/apportioned-emissions/monthly/monthly-apportioned-emissions.service.spec.ts
+++ b/src/apportioned-emissions/monthly/monthly-apportioned-emissions.service.spec.ts
@@ -22,6 +22,8 @@ const mockRepository = () => ({
   getStreamQuery: jest.fn(),
   getEmissionsFacilityAggregation: jest.fn(),
   getFacilityStreamQuery: jest.fn(),
+  getEmissionsStateAggregation: jest.fn(),
+  getStateStreamQuery: jest.fn(),
 });
 
 const mockRequest = () => {
@@ -105,7 +107,7 @@ describe('-- Monthly Apportioned Emissions Service --', () => {
 
   describe('getEmissionsFacilityAggregation', () => {
     it('calls MonthUnitDataRepository.getEmissionsFacilityAggregation() and gets all emissions from the repository', async () => {
-      const expected = [{month: 1}];
+      const expected = [{ month: 1 }];
       repository.getEmissionsFacilityAggregation.mockResolvedValue(expected);
       let filters = new PaginatedMonthlyApportionedEmissionsParamsDTO();
       let result = await service.getEmissionsFacilityAggregation(req, filters);
@@ -130,6 +132,35 @@ describe('-- Monthly Apportioned Emissions Service --', () => {
         new StreamableFile(Buffer.from('stream'), {
           type: req.headers.accept,
           disposition: `attachment; filename="monthly-emissions-facility-aggregation-${0}.json"`,
+        }),
+      );
+    });
+  });
+
+  describe('getEmissionsStateAggregation', () => {
+    it('calls MonthUnitDataRepository.getEmissionsStateAggregation() and gets all emissions from the repository', async () => {
+      const expected = [{ month: 1 }];
+      repository.getEmissionsStateAggregation.mockResolvedValue(expected);
+      let filters = new PaginatedMonthlyApportionedEmissionsParamsDTO();
+      let result = await service.getEmissionsStateAggregation(req, filters);
+      expect(result).toEqual(expected);
+    });
+  });
+
+  describe('streamEmissionsStateAggregation', () => {
+    it('calls MonthUnitDataRepository.getStateStreamQuery() and streams all emissions from the repository', async () => {
+      repository.getStateStreamQuery.mockResolvedValue('');
+
+      let filters = new MonthlyApportionedEmissionsParamsDTO();
+
+      req.headers.accept = '';
+
+      let result = await service.streamEmissionsStateAggregation(req, filters);
+
+      expect(result).toEqual(
+        new StreamableFile(Buffer.from('stream'), {
+          type: req.headers.accept,
+          disposition: `attachment; filename="monthly-emissions-state-aggregation-${0}.json"`,
         }),
       );
     });

--- a/src/constants/field-mappings.ts
+++ b/src/constants/field-mappings.ts
@@ -10,6 +10,7 @@ const dailyStateAggregation = [];
 const dailyNationalAggregation = [];
 const monthly = [];
 const monthlyFacilityAggregation = [];
+const monthlyStateAggregation = [];
 const quarterly = [];
 const annual = [];
 const hourlyMats = [];
@@ -170,6 +171,11 @@ monthlyFacilityAggregation.push(
   ...monthlyAggregationData,
 );
 
+monthlyStateAggregation.push(
+  { ...propertyMetadata.stateCode.fieldLabels },
+  ...monthlyAggregationData,
+);
+
 quarterly.push(
   ...commonCharacteristics,
   { ...propertyMetadata.associatedStacks.fieldLabels },
@@ -286,6 +292,7 @@ export const fieldMappings = {
         aggregation: {
           unit: monthly,
           facility: monthlyFacilityAggregation,
+          state: monthlyStateAggregation,
         },
       },
       excludableColumns: excludableOtherEmissionsColumns,

--- a/src/dto/monthly-apportioned-emissions-state-aggregation.dto.ts
+++ b/src/dto/monthly-apportioned-emissions-state-aggregation.dto.ts
@@ -1,0 +1,15 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { propertyMetadata } from '@us-epa-camd/easey-common/constants';
+import { MonthlyApportionedEmissionsAggregationDTO } from './monthly-apportioned-emissions-aggregation.dto';
+
+export class MonthlyApportionedEmissionsStateAggregationDTO extends MonthlyApportionedEmissionsAggregationDTO {
+  constructor() {
+    super();
+  }
+  @ApiProperty({
+    description: propertyMetadata.stateCode.description,
+    example: propertyMetadata.stateCode.example,
+    name: propertyMetadata.stateCode.fieldLabels.value,
+  })
+  stateCode: string;
+}


### PR DESCRIPTION
## Pull Request

```
- create MonthlyApportionedEmissionsStateAggregationDTO
- modify field mappings 
- add createStateAggregationQuery, getEmissionsStateAggregation, getStateStreamQuery functions in repo
- add state and state/stream endpoints in the controller
- add getEmissionsStateAggregation() and streamEmissionsStateAggregation() to service
- add unit tests

```
