### PR TITLE
bug/3455-swagger-querying-emissions-api-incorrectly-release

### DIFF
--- a/src/apportioned-emissions/annual/annual-apportioned-emissions.controller.ts
+++ b/src/apportioned-emissions/annual/annual-apportioned-emissions.controller.ts
@@ -25,6 +25,7 @@ import {
   ApiQueryMultiSelect,
   ApiProgramQuery,
   ExcludeQuery,
+  ApiQueryAnnually,
 } from '../../utils/swagger-decorator.const';
 
 import { fieldMappings } from '../../constants/field-mappings';
@@ -68,6 +69,7 @@ export class AnnualApportionedEmissionsController {
   @BadRequestResponse()
   @NotFoundResponse()
   @ApiQueryMultiSelect()
+  @ApiQueryAnnually()
   @ApiProgramQuery()
   @UseInterceptors(Json2CsvInterceptor)
   getEmissions(
@@ -99,6 +101,7 @@ export class AnnualApportionedEmissionsController {
   @BadRequestResponse()
   @NotFoundResponse()
   @ApiQueryMultiSelect()
+  @ApiQueryAnnually()
   @ApiProgramQuery()
   @ExcludeQuery()
   streamEmissions(
@@ -115,9 +118,7 @@ export class AnnualApportionedEmissionsController {
     content: {
       'application/json': {
         schema: {
-          $ref: getSchemaPath(
-            AnnualApportionedEmissionsFacilityAggregationDTO,
-          ),
+          $ref: getSchemaPath(AnnualApportionedEmissionsFacilityAggregationDTO),
         },
       },
       'text/csv': {
@@ -133,6 +134,7 @@ export class AnnualApportionedEmissionsController {
   @BadRequestResponse()
   @NotFoundResponse()
   @ApiQueryMultiSelect()
+  @ApiQueryAnnually()
   @ApiProgramQuery()
   @UseInterceptors(Json2CsvInterceptor)
   getEmissionsFacilityAggregation(
@@ -149,9 +151,7 @@ export class AnnualApportionedEmissionsController {
     content: {
       'application/json': {
         schema: {
-          $ref: getSchemaPath(
-            AnnualApportionedEmissionsFacilityAggregationDTO,
-          ),
+          $ref: getSchemaPath(AnnualApportionedEmissionsFacilityAggregationDTO),
         },
       },
       'text/csv': {
@@ -167,6 +167,7 @@ export class AnnualApportionedEmissionsController {
   @BadRequestResponse()
   @NotFoundResponse()
   @ApiQueryMultiSelect()
+  @ApiQueryAnnually()
   @ApiProgramQuery()
   streamEmissionsFacilityAggregation(
     @Req() req: Request,

--- a/src/apportioned-emissions/annual/annual-apportioned-emissions.service.spec.ts
+++ b/src/apportioned-emissions/annual/annual-apportioned-emissions.service.spec.ts
@@ -91,7 +91,7 @@ describe('-- Annual Apportioned Emissions Service --', () => {
   describe('streamEmissions', () => {
     it('calls AnnualUnitDataRepository.streamEmissions() and streams all emissions from the repository', async () => {
       repository.getStreamQuery.mockResolvedValue('');
-      
+
       let filters = new AnnualApportionedEmissionsParamsDTO();
 
       req.headers.accept = '';
@@ -109,7 +109,7 @@ describe('-- Annual Apportioned Emissions Service --', () => {
 
   describe('getEmissionsFacilityAggregation', () => {
     it('calls AnnualUnitDataRepository.getEmissionsFacilityAggregation() and gets all emissions from the repository', async () => {
-      const expected = [{year: 2019}]
+      const expected = [{ year: 2019 }];
       repository.getEmissionsFacilityAggregation.mockResolvedValue(expected);
       let filters = new PaginatedAnnualApportionedEmissionsParamsDTO();
       let result = await service.getEmissionsFacilityAggregation(req, filters);
@@ -125,7 +125,10 @@ describe('-- Annual Apportioned Emissions Service --', () => {
 
       req.headers.accept = '';
 
-      let result = await service.streamEmissionsFacilityAggregation(req, filters);
+      let result = await service.streamEmissionsFacilityAggregation(
+        req,
+        filters,
+      );
 
       expect(result).toEqual(
         new StreamableFile(Buffer.from('stream'), {

--- a/src/apportioned-emissions/daily/daily-apportioned-emissions.controller.ts
+++ b/src/apportioned-emissions/daily/daily-apportioned-emissions.controller.ts
@@ -238,7 +238,7 @@ export class DailyApportionedEmissionsController {
     return this.service.streamEmissionsStateAggregation(req, params);
   }
 
-    @Get('national')
+  @Get('national')
   @ApiOkResponse({
     description:
       'Retrieves Daily Apportioned Emissions National Aggregation data per filter criteria',

--- a/src/apportioned-emissions/daily/daily-apportioned-emissions.service.spec.ts
+++ b/src/apportioned-emissions/daily/daily-apportioned-emissions.service.spec.ts
@@ -109,7 +109,7 @@ describe('-- Daily Apportioned Emissions Service --', () => {
 
   describe('getEmissionsFacilityAggregation', () => {
     it('calls DayUnitDataRepository.getEmissionsFacilityAggregation() and gets all emissions from the repository', async () => {
-      const expected = [{date: '2019-01-01'}]
+      const expected = [{ date: '2019-01-01' }];
       repository.getEmissionsFacilityAggregation.mockResolvedValue(expected);
       let filters = new PaginatedDailyApportionedEmissionsParamsDTO();
       let result = await service.getEmissionsFacilityAggregation(req, filters);
@@ -125,7 +125,10 @@ describe('-- Daily Apportioned Emissions Service --', () => {
 
       req.headers.accept = '';
 
-      let result = await service.streamEmissionsFacilityAggregation(req, filters);
+      let result = await service.streamEmissionsFacilityAggregation(
+        req,
+        filters,
+      );
 
       expect(result).toEqual(
         new StreamableFile(Buffer.from('stream'), {
@@ -138,7 +141,7 @@ describe('-- Daily Apportioned Emissions Service --', () => {
 
   describe('getEmissionsStateAggregation', () => {
     it('calls DayUnitDataRepository.getEmissionsStateAggregation() and gets all emissions from the repository', async () => {
-      const expected = [{date: '2019-01-01'}]
+      const expected = [{ date: '2019-01-01' }];
       repository.getEmissionsStateAggregation.mockResolvedValue(expected);
       let filters = new PaginatedDailyApportionedEmissionsParamsDTO();
       let result = await service.getEmissionsStateAggregation(req, filters);
@@ -167,7 +170,7 @@ describe('-- Daily Apportioned Emissions Service --', () => {
 
   describe('getEmissionsNationalAggregation', () => {
     it('calls DayUnitDataRepository.getEmissionsNationalAggregation() and gets all emissions from the repository', async () => {
-      const expected = [{date: '2019-01-01'}]
+      const expected = [{ date: '2019-01-01' }];
       repository.getEmissionsNationalAggregation.mockResolvedValue(expected);
       let filters = new PaginatedDailyApportionedEmissionsParamsDTO();
       let result = await service.getEmissionsNationalAggregation(req, filters);
@@ -183,7 +186,10 @@ describe('-- Daily Apportioned Emissions Service --', () => {
 
       req.headers.accept = '';
 
-      let result = await service.streamEmissionsNationalAggregation(req, filters);
+      let result = await service.streamEmissionsNationalAggregation(
+        req,
+        filters,
+      );
 
       expect(result).toEqual(
         new StreamableFile(Buffer.from('stream'), {

--- a/src/apportioned-emissions/hourly/hourly-apportioned-emissions.controller.ts
+++ b/src/apportioned-emissions/hourly/hourly-apportioned-emissions.controller.ts
@@ -109,7 +109,7 @@ export class HourlyApportionedEmissionsController {
     @Req() req: Request,
     @Query() params: StreamHourlyApportionedEmissionsParamsDTO,
   ): Promise<StreamableFile> {
-      return this.service.streamEmissions(req, params);
+    return this.service.streamEmissions(req, params);
   }
 
   @Get('facility')

--- a/src/apportioned-emissions/hourly/hourly-apportioned-emissions.service.spec.ts
+++ b/src/apportioned-emissions/hourly/hourly-apportioned-emissions.service.spec.ts
@@ -109,7 +109,7 @@ describe('-- Hourly Apportioned Emissions Service --', () => {
 
   describe('getEmissionsFacilityAggregation', () => {
     it('calls HourUnitDataRepository.getEmissionsFacilityAggregation() and gets all emissions from the repository', async () => {
-      const expected = [{date: '2019-01-01'}]
+      const expected = [{ date: '2019-01-01' }];
       repository.getEmissionsFacilityAggregation.mockResolvedValue(expected);
       let filters = new PaginatedHourlyApportionedEmissionsParamsDTO();
       let result = await service.getEmissionsFacilityAggregation(req, filters);
@@ -125,7 +125,10 @@ describe('-- Hourly Apportioned Emissions Service --', () => {
 
       req.headers.accept = '';
 
-      let result = await service.streamEmissionsFacilityAggregation(req, filters);
+      let result = await service.streamEmissionsFacilityAggregation(
+        req,
+        filters,
+      );
 
       expect(result).toEqual(
         new StreamableFile(Buffer.from('stream'), {
@@ -138,7 +141,7 @@ describe('-- Hourly Apportioned Emissions Service --', () => {
 
   describe('getEmissionsStateAggregation', () => {
     it('calls HourUnitDataRepository.getEmissionsStateAggregation() and gets all emissions from the repository', async () => {
-      const expected = [{date: '2019-01-01'}]
+      const expected = [{ date: '2019-01-01' }];
       repository.getEmissionsStateAggregation.mockResolvedValue(expected);
       let filters = new PaginatedHourlyApportionedEmissionsParamsDTO();
       let result = await service.getEmissionsStateAggregation(req, filters);
@@ -167,7 +170,7 @@ describe('-- Hourly Apportioned Emissions Service --', () => {
 
   describe('getEmissionsNationalAggregation', () => {
     it('calls HourUnitDataRepository.getEmissionsNationalAggregation() and gets all emissions from the repository', async () => {
-      const expected = [{date: '2019-01-01'}]
+      const expected = [{ date: '2019-01-01' }];
       repository.getEmissionsNationalAggregation.mockResolvedValue(expected);
       let filters = new PaginatedHourlyApportionedEmissionsParamsDTO();
       let result = await service.getEmissionsNationalAggregation(req, filters);
@@ -183,7 +186,10 @@ describe('-- Hourly Apportioned Emissions Service --', () => {
 
       req.headers.accept = '';
 
-      let result = await service.streamEmissionsNationalAggregation(req, filters);
+      let result = await service.streamEmissionsNationalAggregation(
+        req,
+        filters,
+      );
 
       expect(result).toEqual(
         new StreamableFile(Buffer.from('stream'), {

--- a/src/apportioned-emissions/mats/mats-apportioned-emissions.module.ts
+++ b/src/apportioned-emissions/mats/mats-apportioned-emissions.module.ts
@@ -9,7 +9,11 @@ import { HourlyMatsApportionedEmissionsModule } from './hourly/hourly-mats-appor
 import { HourUnitMatsDataRepository } from './hourly/hour-unit-mats-data.repository';
 
 @Module({
-  imports: [TypeOrmModule.forFeature([HourUnitMatsDataRepository]), HourlyMatsApportionedEmissionsModule, HttpModule],
+  imports: [
+    TypeOrmModule.forFeature([HourUnitMatsDataRepository]),
+    HourlyMatsApportionedEmissionsModule,
+    HttpModule,
+  ],
   controllers: [MatsApportionedEmissionsController],
   providers: [ConfigService, MatsApportionedEmissionsService],
   exports: [TypeOrmModule],

--- a/src/apportioned-emissions/mats/mats-apportioned-emissions.service.spec.ts
+++ b/src/apportioned-emissions/mats/mats-apportioned-emissions.service.spec.ts
@@ -1,7 +1,6 @@
 import { Test } from '@nestjs/testing';
 import { LoggerModule } from '@us-epa-camd/easey-common/logger';
 
-
 import { MatsApportionedEmissionsService } from './mats-apportioned-emissions.service';
 import { ApplicableMatsApportionedEmissionsAttributesParamsDTO } from '../../dto/applicable-mats-apportioned-emissions-attributes-params.dto';
 import { HourUnitMatsDataRepository } from './hourly/hour-unit-mats-data.repository';
@@ -48,7 +47,7 @@ describe('-- MATS Apportioned Emissions Service --', () => {
     it('calls HourUnitDataRepository.getApplicableEmissions() and gets all applicable emissions attributes from the repository', async () => {
       const expected: HourUnitMatsDataArch[] = [];
       repository.getApplicableEmissions.mockResolvedValue(expected);
-      repository.lastArchivedDate.mockResolvedValue('2019-01-01')
+      repository.lastArchivedDate.mockResolvedValue('2019-01-01');
       let filters = new ApplicableMatsApportionedEmissionsAttributesParamsDTO();
       let result = await service.getApplicableEmissions(filters);
       expect(result).toEqual(expected);

--- a/src/apportioned-emissions/monthly/monthly-apportioned-emissions.controller.ts
+++ b/src/apportioned-emissions/monthly/monthly-apportioned-emissions.controller.ts
@@ -146,7 +146,6 @@ export class MonthlyApportionedEmissionsController {
     @Req() req: Request,
     @Query() params: PaginatedMonthlyApportionedEmissionsParamsDTO,
   ): Promise<MonthlyApportionedEmissionsFacilityAggregationDTO[]> {
-    console.log('getEmissionsFacilityAggregation');
     return this.service.getEmissionsFacilityAggregation(req, params);
   }
 

--- a/src/apportioned-emissions/monthly/monthly-apportioned-emissions.controller.ts
+++ b/src/apportioned-emissions/monthly/monthly-apportioned-emissions.controller.ts
@@ -73,6 +73,7 @@ export class MonthlyApportionedEmissionsController {
   @NotFoundResponse()
   @ApiQueryMultiSelect()
   @ApiProgramQuery()
+  @ApiQueryMonthly()
   @UseInterceptors(Json2CsvInterceptor)
   getEmissions(
     @Req() req: Request,
@@ -104,6 +105,7 @@ export class MonthlyApportionedEmissionsController {
   @NotFoundResponse()
   @ApiQueryMultiSelect()
   @ApiProgramQuery()
+  @ApiQueryMonthly()
   @ExcludeQuery()
   streamEmissions(
     @Req() req: Request,
@@ -144,6 +146,7 @@ export class MonthlyApportionedEmissionsController {
     @Req() req: Request,
     @Query() params: PaginatedMonthlyApportionedEmissionsParamsDTO,
   ): Promise<MonthlyApportionedEmissionsFacilityAggregationDTO[]> {
+    console.log('getEmissionsFacilityAggregation');
     return this.service.getEmissionsFacilityAggregation(req, params);
   }
 

--- a/src/apportioned-emissions/ozone/ozone-apportioned-emissions.controller.ts
+++ b/src/apportioned-emissions/ozone/ozone-apportioned-emissions.controller.ts
@@ -25,6 +25,7 @@ import {
   ApiQueryMultiSelect,
   ApiProgramQuery,
   ExcludeQuery,
+  ApiQueryAnnually,
 } from '../../utils/swagger-decorator.const';
 
 import { fieldMappings } from '../../constants/field-mappings';
@@ -65,6 +66,7 @@ export class OzoneApportionedEmissionsController {
   @BadRequestResponse()
   @NotFoundResponse()
   @ApiQueryMultiSelect()
+  @ApiQueryAnnually()
   @ApiProgramQuery()
   @UseInterceptors(Json2CsvInterceptor)
   getEmissions(
@@ -96,6 +98,7 @@ export class OzoneApportionedEmissionsController {
   @BadRequestResponse()
   @NotFoundResponse()
   @ApiQueryMultiSelect()
+  @ApiQueryAnnually()
   @ApiProgramQuery()
   @ExcludeQuery()
   streamEmissions(

--- a/src/apportioned-emissions/quarterly/quarterly-apportioned-emissions.controller.ts
+++ b/src/apportioned-emissions/quarterly/quarterly-apportioned-emissions.controller.ts
@@ -25,6 +25,7 @@ import {
   ApiQueryMultiSelect,
   ApiProgramQuery,
   ExcludeQuery,
+  ApiQueryQuarterly,
 } from '../../utils/swagger-decorator.const';
 
 import { fieldMappings } from '../../constants/field-mappings';
@@ -67,6 +68,7 @@ export class QuarterlyApportionedEmissionsController {
   @NotFoundResponse()
   @ApiQueryMultiSelect()
   @ApiProgramQuery()
+  @ApiQueryQuarterly()
   @UseInterceptors(Json2CsvInterceptor)
   getEmissions(
     @Req() req: Request,
@@ -97,6 +99,7 @@ export class QuarterlyApportionedEmissionsController {
   @BadRequestResponse()
   @NotFoundResponse()
   @ApiQueryMultiSelect()
+  @ApiQueryQuarterly()
   @ApiProgramQuery()
   @ExcludeQuery()
   streamEmissions(

--- a/src/dto/apportioned-emissions.params.dto.spec.ts
+++ b/src/dto/apportioned-emissions.params.dto.spec.ts
@@ -6,9 +6,7 @@ import { IsInValidReportingQuarter } from '../pipes/is-in-valid-reporting-quarte
 describe('-- Apportioned Emissions Params DTO --', () => {
   describe('getHourlyEmissions with query parameters', () => {
     class MyClass {
-      constructor(
-        month: string,
-      ) {
+      constructor(month: string) {
         this.month = month;
       }
       @IsValidNumber(12)
@@ -17,20 +15,12 @@ describe('-- Apportioned Emissions Params DTO --', () => {
     }
 
     it('should pass all validation pipes', async () => {
-      const results = await validate(
-        new MyClass(
-          '3'
-        ),
-      );
+      const results = await validate(new MyClass('3'));
       expect(results.length).toBe(0);
     });
 
     it('should fail one of validation pipes (month)', async () => {
-      const results = await validate(
-        new MyClass(
-          'invalid'
-        ),
-      );
+      const results = await validate(new MyClass('invalid'));
       expect(results.length).toBe(1);
     });
   });

--- a/src/entities/hour-unit-mats-data-arch.entity.ts
+++ b/src/entities/hour-unit-mats-data-arch.entity.ts
@@ -1,4 +1,10 @@
-import { Column, ViewEntity, PrimaryColumn, ManyToOne, JoinColumn } from 'typeorm';
+import {
+  Column,
+  ViewEntity,
+  PrimaryColumn,
+  ManyToOne,
+  JoinColumn,
+} from 'typeorm';
 import { NumericColumnTransformer } from '@us-epa-camd/easey-common/transforms';
 import { UnitFact } from './unit-fact.entity';
 

--- a/src/entities/hour-unit-mats-data.entity.ts
+++ b/src/entities/hour-unit-mats-data.entity.ts
@@ -1,4 +1,10 @@
-import { Column, ViewEntity, PrimaryColumn, ManyToOne, JoinColumn } from 'typeorm';
+import {
+  Column,
+  ViewEntity,
+  PrimaryColumn,
+  ManyToOne,
+  JoinColumn,
+} from 'typeorm';
 import { NumericColumnTransformer } from '@us-epa-camd/easey-common/transforms';
 import { UnitFact } from './unit-fact.entity';
 

--- a/src/entities/unit-fact.entity.ts
+++ b/src/entities/unit-fact.entity.ts
@@ -1,10 +1,4 @@
-import {
-  BaseEntity,
-  Column,
-  Entity,
-  OneToMany,
-  PrimaryColumn,
-} from 'typeorm';
+import { BaseEntity, Column, Entity, OneToMany, PrimaryColumn } from 'typeorm';
 
 import { NumericColumnTransformer } from '@us-epa-camd/easey-common/transforms';
 

--- a/src/entities/vw-annual-unit-data.entity.ts
+++ b/src/entities/vw-annual-unit-data.entity.ts
@@ -2,7 +2,7 @@ import { Column, ViewEntity } from 'typeorm';
 import { NumericColumnTransformer } from '@us-epa-camd/easey-common/transforms';
 
 @ViewEntity({
-  name: 'camddmw.vw_annual_unit_data'
+  name: 'camddmw.vw_annual_unit_data',
 })
 export class AnnualUnitDataView {
   @Column({ name: 'state' })

--- a/src/entities/vw-day-unit-data.entity.ts
+++ b/src/entities/vw-day-unit-data.entity.ts
@@ -2,7 +2,7 @@ import { Column, ViewEntity } from 'typeorm';
 import { NumericColumnTransformer } from '@us-epa-camd/easey-common/transforms';
 
 @ViewEntity({
-  name: 'camddmw.vw_day_unit_data'
+  name: 'camddmw.vw_day_unit_data',
 })
 export class DayUnitDataView {
   @Column({ name: 'state' })

--- a/src/entities/vw-hour-unit-data.entity.ts
+++ b/src/entities/vw-hour-unit-data.entity.ts
@@ -2,7 +2,7 @@ import { Column, ViewEntity } from 'typeorm';
 import { NumericColumnTransformer } from '@us-epa-camd/easey-common/transforms';
 
 @ViewEntity({
-  name: 'camddmw.vw_hour_unit_data'
+  name: 'camddmw.vw_hour_unit_data',
 })
 export class HourUnitDataView {
   @Column({ name: 'state' })

--- a/src/entities/vw-month-unit-data.entity.ts
+++ b/src/entities/vw-month-unit-data.entity.ts
@@ -2,7 +2,7 @@ import { Column, ViewEntity } from 'typeorm';
 import { NumericColumnTransformer } from '@us-epa-camd/easey-common/transforms';
 
 @ViewEntity({
-  name: 'camddmw.vw_month_unit_data'
+  name: 'camddmw.vw_month_unit_data',
 })
 export class MonthUnitDataView {
   @Column({ name: 'state' })

--- a/src/entities/vw-ozone-unit-data.entity.ts
+++ b/src/entities/vw-ozone-unit-data.entity.ts
@@ -2,7 +2,7 @@ import { Column, ViewEntity } from 'typeorm';
 import { NumericColumnTransformer } from '@us-epa-camd/easey-common/transforms';
 
 @ViewEntity({
-  name: 'camddmw.vw_ozone_unit_data'
+  name: 'camddmw.vw_ozone_unit_data',
 })
 export class OzoneUnitDataView {
   @Column({ name: 'state' })

--- a/src/entities/vw-quarter-unit-data.entity.ts
+++ b/src/entities/vw-quarter-unit-data.entity.ts
@@ -2,7 +2,7 @@ import { Column, ViewEntity } from 'typeorm';
 import { NumericColumnTransformer } from '@us-epa-camd/easey-common/transforms';
 
 @ViewEntity({
-  name: 'camddmw.vw_quarter_unit_data'
+  name: 'camddmw.vw_quarter_unit_data',
 })
 export class QuarterUnitDataView {
   @Column({ name: 'state' })

--- a/src/pipes/is-in-valid-reporting-quarter.pipe.ts
+++ b/src/pipes/is-in-valid-reporting-quarter.pipe.ts
@@ -19,7 +19,9 @@ export function IsInValidReportingQuarter(
       validator: {
         validate(value: any, args: ValidationArguments) {
           const [relatedPropertyName] = args.constraints;
-          const relatedValue = (args.object as unknown as number)[relatedPropertyName];
+          const relatedValue = ((args.object as unknown) as number)[
+            relatedPropertyName
+          ];
           const curDate = new Date();
           const curYear = new Date().getFullYear();
           const yearIndicator =

--- a/src/pipes/is-state-code.pipe.ts
+++ b/src/pipes/is-state-code.pipe.ts
@@ -2,16 +2,16 @@ import {
   registerDecorator,
   ValidationOptions,
   ValidationArguments,
-} from "class-validator";
+} from 'class-validator';
 
-import { getManager } from "typeorm";
+import { getManager } from 'typeorm';
 
-import { StateCode } from "../entities/state-code.entity";
+import { StateCode } from '../entities/state-code.entity';
 
 export function IsStateCode(validationOptions?: ValidationOptions) {
-  return function (object: Object, propertyName: string) {
+  return function(object: Object, propertyName: string) {
     registerDecorator({
-      name: "isStateCode",
+      name: 'isStateCode',
       target: object.constructor,
       propertyName: propertyName,
       options: validationOptions,

--- a/src/utils/query-builder.helper.ts
+++ b/src/utils/query-builder.helper.ts
@@ -1,8 +1,12 @@
 import { Regex } from '@us-epa-camd/easey-common/utilities';
 
 export class QueryBuilderHelper {
-
-  public static whereBeginDate(query: any, beginDate: Date, params: string[], alias: string) {
+  public static whereBeginDate(
+    query: any,
+    beginDate: Date,
+    params: string[],
+    alias: string,
+  ) {
     if (params.includes('beginDate') && beginDate) {
       query.andWhere(`${alias}.date >= :beginDate`, {
         beginDate: beginDate,
@@ -12,7 +16,12 @@ export class QueryBuilderHelper {
     return query;
   }
 
-  public static whereEndDate(query: any, endDate: Date, params: string[], alias: string) {
+  public static whereEndDate(
+    query: any,
+    endDate: Date,
+    params: string[],
+    alias: string,
+  ) {
     if (params.includes('endDate') && endDate) {
       query.andWhere(`${alias}.date <= :endDate`, {
         endDate: endDate,
@@ -22,7 +31,12 @@ export class QueryBuilderHelper {
     return query;
   }
 
-  public static whereYear(query: any, year: number[], params: string[], alias: string) {
+  public static whereYear(
+    query: any,
+    year: number[],
+    params: string[],
+    alias: string,
+  ) {
     if (params.includes('year') && year) {
       query.andWhere(`${alias}.year IN (:...years)`, {
         years: year,
@@ -32,7 +46,12 @@ export class QueryBuilderHelper {
     return query;
   }
 
-  public static whereQuarter(query: any, quarter: number[], params: string[], alias: string) {
+  public static whereQuarter(
+    query: any,
+    quarter: number[],
+    params: string[],
+    alias: string,
+  ) {
     if (params.includes('quarter') && quarter) {
       query.andWhere(`${alias}.quarter IN (:...quarters)`, {
         quarters: quarter,
@@ -42,7 +61,12 @@ export class QueryBuilderHelper {
     return query;
   }
 
-  public static whereMonth(query: any, month: number[], params: string[], alias: string) {
+  public static whereMonth(
+    query: any,
+    month: number[],
+    params: string[],
+    alias: string,
+  ) {
     if (params.includes('month') && month) {
       query.andWhere(`${alias}.month IN (:...months)`, {
         months: month,
@@ -52,7 +76,12 @@ export class QueryBuilderHelper {
     return query;
   }
 
-  public static whereStateCode(query: any, stateCode: string[], params: string[], alias: string) {
+  public static whereStateCode(
+    query: any,
+    stateCode: string[],
+    params: string[],
+    alias: string,
+  ) {
     if (params.includes('stateCode') && stateCode) {
       query.andWhere(`${alias}.stateCode IN (:...states)`, {
         states: stateCode.map(states => {
@@ -64,7 +93,12 @@ export class QueryBuilderHelper {
     return query;
   }
 
-  public static whereFacilityId(query: any, facilityId: number[], params: string[], alias: string) {
+  public static whereFacilityId(
+    query: any,
+    facilityId: number[],
+    params: string[],
+    alias: string,
+  ) {
     if (params.includes('facilityId') && facilityId) {
       query.andWhere(`${alias}.facilityId IN (:...facilityIds)`, {
         facilityIds: facilityId,
@@ -74,7 +108,12 @@ export class QueryBuilderHelper {
     return query;
   }
 
-  public static whereUnitType(query: any, unitType: string[], params: string[], alias: string) {
+  public static whereUnitType(
+    query: any,
+    unitType: string[],
+    params: string[],
+    alias: string,
+  ) {
     if (params.includes('unitType') && unitType) {
       let string = '(';
 
@@ -95,7 +134,12 @@ export class QueryBuilderHelper {
     return query;
   }
 
-  public static whereUnitFuel(query: any, unitFuel: string[], params: string[], alias: string) {
+  public static whereUnitFuel(
+    query: any,
+    unitFuel: string[],
+    params: string[],
+    alias: string,
+  ) {
     if (params.includes('unitFuelType') && unitFuel) {
       let string = '(';
 
@@ -118,14 +162,17 @@ export class QueryBuilderHelper {
     return query;
   }
 
-  public static whereControlTech(query: any, cntrlTech: string[], params: string[], alias: string) {
+  public static whereControlTech(
+    query: any,
+    cntrlTech: string[],
+    params: string[],
+    alias: string,
+  ) {
     if (params.includes('controlTechnologies') && cntrlTech) {
       let string = '(';
 
       for (let i = 0; i < cntrlTech.length; i++) {
-        const regex = Regex.commaDelimited(
-          cntrlTech[i].toUpperCase(),
-        );
+        const regex = Regex.commaDelimited(cntrlTech[i].toUpperCase());
 
         if (i === 0) {
           string += `(UPPER(${alias}.so2ControlInfo) ~* ${regex}) `;
@@ -145,14 +192,17 @@ export class QueryBuilderHelper {
     return query;
   }
 
-  public static whereProgramCode(query: any, prgCode: string[], params: string[], alias: string) {
+  public static whereProgramCode(
+    query: any,
+    prgCode: string[],
+    params: string[],
+    alias: string,
+  ) {
     if (params.includes('programCodeInfo') && prgCode) {
       let string = '(';
 
       for (let i = 0; i < prgCode.length; i++) {
-        const regex = Regex.commaDelimited(
-          prgCode[i].toUpperCase(),
-        );
+        const regex = Regex.commaDelimited(prgCode[i].toUpperCase());
 
         if (i === 0) {
           string += `(UPPER(${alias}.programCodeInfo) ~* ${regex}) `;
@@ -168,8 +218,15 @@ export class QueryBuilderHelper {
     return query;
   }
 
-  public static whereOperatingHoursOnly(query: any, opHrsOnly: boolean, params: string[], alias: string) {
-    if (params.includes('operatingHoursOnly') && String(opHrsOnly) === String(true)
+  public static whereOperatingHoursOnly(
+    query: any,
+    opHrsOnly: boolean,
+    params: string[],
+    alias: string,
+  ) {
+    if (
+      params.includes('operatingHoursOnly') &&
+      String(opHrsOnly) === String(true)
     ) {
       query.andWhere(`${alias}.opTime > 0`);
     }
@@ -192,9 +249,19 @@ export class QueryBuilderHelper {
     query = this.whereFacilityId(query, dto.facilityId, params, alias);
     query = this.whereUnitType(query, dto.unitType, params, alias);
     query = this.whereUnitFuel(query, dto.unitFuelType, params, alias);
-    query = this.whereControlTech(query, dto.controlTechnologies, params, alias);
+    query = this.whereControlTech(
+      query,
+      dto.controlTechnologies,
+      params,
+      alias,
+    );
     query = this.whereProgramCode(query, dto.programCodeInfo, params, alias);
-    query = this.whereOperatingHoursOnly(query, dto.operatingHoursOnly, params, alias);
+    query = this.whereOperatingHoursOnly(
+      query,
+      dto.operatingHoursOnly,
+      params,
+      alias,
+    );
 
     if (dto.page && dto.perPage) {
       query = query.skip((dto.page - 1) * dto.perPage).take(dto.perPage);

--- a/src/utils/swagger-decorator.const.ts
+++ b/src/utils/swagger-decorator.const.ts
@@ -17,26 +17,100 @@ export const NotFoundResponse = () =>
 
 export function ApiQueryMultiSelect() {
   return applyDecorators(
-    ApiQuery({style: 'pipeDelimited', name: 'stateCode', required: false, explode: false,}),
-    ApiQuery({style: 'pipeDelimited', name: 'facilityId', required: false, explode: false,}),
-    ApiQuery({style: 'pipeDelimited', name: 'unitType', required: false, explode: false,}),
-    ApiQuery({style: 'pipeDelimited', name: 'controlTechnologies', required: false, explode: false,}),
-    ApiQuery({style: 'pipeDelimited', name: 'unitFuelType', required: false, explode: false,}),
+    ApiQuery({
+      style: 'pipeDelimited',
+      name: 'stateCode',
+      required: false,
+      explode: false,
+    }),
+    ApiQuery({
+      style: 'pipeDelimited',
+      name: 'facilityId',
+      required: false,
+      explode: false,
+    }),
+    ApiQuery({
+      style: 'pipeDelimited',
+      name: 'unitType',
+      required: false,
+      explode: false,
+    }),
+    ApiQuery({
+      style: 'pipeDelimited',
+      name: 'controlTechnologies',
+      required: false,
+      explode: false,
+    }),
+    ApiQuery({
+      style: 'pipeDelimited',
+      name: 'unitFuelType',
+      required: false,
+      explode: false,
+    }),
   );
 }
 export function ApiQueryMonthly() {
   return applyDecorators(
-    ApiQuery({style: 'pipeDelimited', name: 'month', required: true, explode: false,}),
-    ApiQuery({style: 'pipeDelimited', name: 'year', required: true, explode: false,})
-  )
+    ApiQuery({
+      style: 'pipeDelimited',
+      name: 'month',
+      required: true,
+      explode: false,
+    }),
+    ApiQuery({
+      style: 'pipeDelimited',
+      name: 'year',
+      required: true,
+      explode: false,
+    }),
+  );
 }
+
+export function ApiQueryQuarterly() {
+  return applyDecorators(
+    ApiQuery({
+      style: 'pipeDelimited',
+      name: 'year',
+      required: true,
+      explode: false,
+    }),
+    ApiQuery({
+      style: 'pipeDelimited',
+      name: 'quarter',
+      required: true,
+      explode: false,
+    }),
+  );
+}
+
+export function ApiQueryAnnually() {
+  return applyDecorators(
+    ApiQuery({
+      style: 'pipeDelimited',
+      name: 'year',
+      required: true,
+      explode: false,
+    }),
+  );
+}
+
 export function ApiProgramQuery() {
   return applyDecorators(
-    ApiQuery({style: 'pipeDelimited', name: 'programCodeInfo', required: false, explode: false,})
+    ApiQuery({
+      style: 'pipeDelimited',
+      name: 'programCodeInfo',
+      required: false,
+      explode: false,
+    }),
   );
 }
 export function ExcludeQuery() {
   return applyDecorators(
-    ApiQuery({style: 'pipeDelimited', name: 'exclude', required: false, explode: false,})
+    ApiQuery({
+      style: 'pipeDelimited',
+      name: 'exclude',
+      required: false,
+      explode: false,
+    }),
   );
 }

--- a/src/utils/validator.const.ts
+++ b/src/utils/validator.const.ts
@@ -9,7 +9,7 @@ import {
   IsYearFormat,
   IsNotEmptyString,
   IsInRange,
-  Min
+  Min,
 } from '@us-epa-camd/easey-common/pipes';
 import { PAGINATION_MAX_PER_PAGE } from '../config/app.config';
 


### PR DESCRIPTION
Fixed issues with swagger arguments exploding improperly for quarterly, annually, monthly, and ozone.

I also ran yarn format on the entire code base so more files were changed than just the ones required for the above changes.

