### PR TITLE
bug/3455-swagger-querying-emissions-api-incorrectly

### DIFF
--- a/src/apportioned-emissions/annual/annual-apportioned-emissions.controller.ts
+++ b/src/apportioned-emissions/annual/annual-apportioned-emissions.controller.ts
@@ -25,6 +25,7 @@ import {
   ApiQueryMultiSelect,
   ApiProgramQuery,
   ExcludeQuery,
+  ApiQueryAnnually,
 } from '../../utils/swagger-decorator.const';
 
 import { fieldMappings } from '../../constants/field-mappings';
@@ -41,7 +42,7 @@ import {
 @ApiTags('Apportioned Annual Emissions')
 @ApiExtraModels(AnnualApportionedEmissionsDTO)
 export class AnnualApportionedEmissionsController {
-  constructor(private readonly service: AnnualApportionedEmissionsService) {}
+  constructor(private readonly service: AnnualApportionedEmissionsService) { }
 
   @Get()
   @ApiOkResponse({
@@ -63,6 +64,7 @@ export class AnnualApportionedEmissionsController {
   @BadRequestResponse()
   @NotFoundResponse()
   @ApiQueryMultiSelect()
+  @ApiQueryAnnually()
   @ApiProgramQuery()
   @UseInterceptors(Json2CsvInterceptor)
   getEmissions(
@@ -92,6 +94,7 @@ export class AnnualApportionedEmissionsController {
   @BadRequestResponse()
   @NotFoundResponse()
   @ApiQueryMultiSelect()
+  @ApiQueryAnnually()
   @ApiProgramQuery()
   @ExcludeQuery()
   streamEmissions(

--- a/src/apportioned-emissions/monthly/monthly-apportioned-emissions.controller.ts
+++ b/src/apportioned-emissions/monthly/monthly-apportioned-emissions.controller.ts
@@ -25,6 +25,7 @@ import {
   ApiQueryMultiSelect,
   ApiProgramQuery,
   ExcludeQuery,
+  ApiQueryMonthly,
 } from '../../utils/swagger-decorator.const';
 import { fieldMappings } from '../../constants/field-mappings';
 import { MonthUnitDataView } from './../../entities/vw-month-unit-data.entity';
@@ -40,7 +41,7 @@ import {
 @ApiTags('Apportioned Monthly Emissions')
 @ApiExtraModels(MonthlyApportionedEmissionsDTO)
 export class MonthlyApportionedEmissionsController {
-  constructor(private readonly service: MonthlyApportionedEmissionsService) {}
+  constructor(private readonly service: MonthlyApportionedEmissionsService) { }
 
   @Get()
   @ApiOkResponse({
@@ -62,6 +63,7 @@ export class MonthlyApportionedEmissionsController {
   @BadRequestResponse()
   @NotFoundResponse()
   @ApiQueryMultiSelect()
+  @ApiQueryMonthly()
   @ApiProgramQuery()
   @UseInterceptors(Json2CsvInterceptor)
   getEmissions(
@@ -91,6 +93,7 @@ export class MonthlyApportionedEmissionsController {
   @BadRequestResponse()
   @NotFoundResponse()
   @ApiQueryMultiSelect()
+  @ApiQueryMonthly()
   @ApiProgramQuery()
   @ExcludeQuery()
   streamEmissions(

--- a/src/apportioned-emissions/ozone/ozone-apportioned-emissions.controller.ts
+++ b/src/apportioned-emissions/ozone/ozone-apportioned-emissions.controller.ts
@@ -25,6 +25,7 @@ import {
   ApiQueryMultiSelect,
   ApiProgramQuery,
   ExcludeQuery,
+  ApiQueryAnnually,
 } from '../../utils/swagger-decorator.const';
 
 import { fieldMappings } from '../../constants/field-mappings';
@@ -41,7 +42,7 @@ import {
 @ApiTags('Apportioned Ozone Emissions')
 @ApiExtraModels(OzoneApportionedEmissionsDTO)
 export class OzoneApportionedEmissionsController {
-  constructor(private readonly service: OzoneApportionedEmissionsService) {}
+  constructor(private readonly service: OzoneApportionedEmissionsService) { }
 
   @Get()
   @ApiOkResponse({
@@ -63,6 +64,7 @@ export class OzoneApportionedEmissionsController {
   @BadRequestResponse()
   @NotFoundResponse()
   @ApiQueryMultiSelect()
+  @ApiQueryAnnually()
   @ApiProgramQuery()
   @UseInterceptors(Json2CsvInterceptor)
   getEmissions(
@@ -92,6 +94,7 @@ export class OzoneApportionedEmissionsController {
   @BadRequestResponse()
   @NotFoundResponse()
   @ApiQueryMultiSelect()
+  @ApiQueryAnnually()
   @ApiProgramQuery()
   @ExcludeQuery()
   streamEmissions(

--- a/src/apportioned-emissions/quarterly/quarterly-apportioned-emissions.controller.ts
+++ b/src/apportioned-emissions/quarterly/quarterly-apportioned-emissions.controller.ts
@@ -25,6 +25,7 @@ import {
   ApiQueryMultiSelect,
   ApiProgramQuery,
   ExcludeQuery,
+  ApiQueryQuarterly,
 } from '../../utils/swagger-decorator.const';
 
 import { fieldMappings } from '../../constants/field-mappings';
@@ -41,7 +42,7 @@ import {
 @ApiTags('Apportioned Quarterly Emissions')
 @ApiExtraModels(QuarterlyApportionedEmissionsDTO)
 export class QuarterlyApportionedEmissionsController {
-  constructor(private readonly service: QuarterlyApportionedEmissionsService) {}
+  constructor(private readonly service: QuarterlyApportionedEmissionsService) { }
 
   @Get()
   @ApiOkResponse({
@@ -66,6 +67,7 @@ export class QuarterlyApportionedEmissionsController {
   @BadRequestResponse()
   @NotFoundResponse()
   @ApiQueryMultiSelect()
+  @ApiQueryQuarterly()
   @ApiProgramQuery()
   @UseInterceptors(Json2CsvInterceptor)
   getEmissions(
@@ -97,6 +99,7 @@ export class QuarterlyApportionedEmissionsController {
   @BadRequestResponse()
   @NotFoundResponse()
   @ApiQueryMultiSelect()
+  @ApiQueryQuarterly()
   @ApiProgramQuery()
   @ExcludeQuery()
   streamEmissions(

--- a/src/utils/swagger-decorator.const.ts
+++ b/src/utils/swagger-decorator.const.ts
@@ -17,20 +17,41 @@ export const NotFoundResponse = () =>
 
 export function ApiQueryMultiSelect() {
   return applyDecorators(
-    ApiQuery({style: 'pipeDelimited', name: 'stateCode', required: false, explode: false,}),
-    ApiQuery({style: 'pipeDelimited', name: 'facilityId', required: false, explode: false,}),
-    ApiQuery({style: 'pipeDelimited', name: 'unitType', required: false, explode: false,}),
-    ApiQuery({style: 'pipeDelimited', name: 'controlTechnologies', required: false, explode: false,}),
-    ApiQuery({style: 'pipeDelimited', name: 'unitFuelType', required: false, explode: false,}),
+    ApiQuery({ style: 'pipeDelimited', name: 'stateCode', required: false, explode: false, }),
+    ApiQuery({ style: 'pipeDelimited', name: 'facilityId', required: false, explode: false, }),
+    ApiQuery({ style: 'pipeDelimited', name: 'unitType', required: false, explode: false, }),
+    ApiQuery({ style: 'pipeDelimited', name: 'controlTechnologies', required: false, explode: false, }),
+    ApiQuery({ style: 'pipeDelimited', name: 'unitFuelType', required: false, explode: false, }),
   );
 }
+
+export function ApiQueryQuarterly() {
+  return applyDecorators(
+    ApiQuery({ style: 'pipeDelimited', name: 'year', required: true, explode: false, }),
+    ApiQuery({ style: 'pipeDelimited', name: 'quarter', required: true, explode: false, }),
+  );
+}
+
+export function ApiQueryAnnually() {
+  return applyDecorators(
+    ApiQuery({ style: 'pipeDelimited', name: 'year', required: true, explode: false, }),
+  );
+}
+
+export function ApiQueryMonthly() {
+  return applyDecorators(
+    ApiQuery({ style: 'pipeDelimited', name: 'month', required: true, explode: false, }),
+    ApiQuery({ style: 'pipeDelimited', name: 'year', required: true, explode: false, }),
+  );
+}
+
 export function ApiProgramQuery() {
   return applyDecorators(
-    ApiQuery({style: 'pipeDelimited',name: 'programCodeInfo',required: false,explode: false,})
+    ApiQuery({ style: 'pipeDelimited', name: 'programCodeInfo', required: false, explode: false, })
   );
 }
 export function ExcludeQuery() {
   return applyDecorators(
-    ApiQuery({style: 'pipeDelimited', name: 'exclude', required: false, explode: false,})
+    ApiQuery({ style: 'pipeDelimited', name: 'exclude', required: false, explode: false, })
   );
 }


### PR DESCRIPTION
## Pull Request
This PR fixes the issue with the arguments in swagger exploding incorrectly for monthly, annually, quarterly, and ozone.
