### PR TITLE
Json Upload Size Limit Increase

### DIFF
--- a/src/config/app.config.ts
+++ b/src/config/app.config.ts
@@ -66,6 +66,10 @@ export default registerAs('app', () => ({
   submissionDays: getConfigValueNumber(
     'EASEY_EMISSIONS_API_SUBMISSION_DAYS', 38,
   ),
+  reqSizeLimit: getConfigValue(
+    'EASEY_EMISSIONS_API_REQ_SIZE_LIMIT',
+    '30mb',
+  ),
   // ENABLES DEBUG CONSOLE LOGS
   enableDebug: getConfigValueBoolean(
     'EASEY_EMISSIONS_API_ENABLE_DEBUG',

--- a/src/emissions-workspace/emissions.service.ts
+++ b/src/emissions-workspace/emissions.service.ts
@@ -142,8 +142,8 @@ export class EmissionsWorkspaceService {
 
     const filteredMonitorPlans = plantLocation.monitorPlans?.filter(plan => {
       return (
-        plan.beginRptPeriod.year === params.year &&
-        plan.beginRptPeriod.quarter === params.quarter
+        plan.beginRptPeriod.year <= params.year &&
+        plan.beginRptPeriod.quarter <= params.quarter
       );
     });
 


### PR DESCRIPTION
This PR adds the EASEY_EMISSIONS_API_REQ_SIZE_LIMIT env variable which sets the max JSON size we can POST. The default is set to 30mb.

It also makes a small tweak to the logic for matching monitoring plans in emissions service.


