### PR TITLE
Feature/4462 Implement Reporting Period Limit Selection in the Emissions View API Endpoints

### DIFF
--- a/src/dto/emissions-view.params.dto.ts
+++ b/src/dto/emissions-view.params.dto.ts
@@ -8,6 +8,7 @@ import {
 import { OneOrMore } from '../pipes/one-or-more.pipe';
 import { IsReportingPeriodFormat } from '../pipes/is-reporting-period-format.pipe';
 import { IsInReportingPeriodRange } from '../pipes/is-in-reporting-period.pipe';
+import { ArrayMaxLength } from '../pipes/array-max-length.pipe';
 
 export class EmissionsViewParamsDTO {
   @ApiProperty()
@@ -44,6 +45,9 @@ export class EmissionsViewParamsDTO {
       'The Year and Quarter cannot be before 2009 and cannot surpass the current date',
   })
   @Transform(({ value }) => value.split('|').map((item: string) => item.trim()))
+  @ArrayMaxLength(4, {
+    message: 'You can only select a maximum of four reporting periods',
+  })
   reportingPeriod: string[];
 
   @ApiProperty({

--- a/src/pipes/array-max-length.pipe.ts
+++ b/src/pipes/array-max-length.pipe.ts
@@ -1,29 +1,22 @@
-import { isInReportingPeriodRange } from '../utils/reporting-period-validation';
 import {
   registerDecorator,
   ValidationOptions,
   ValidationArguments,
 } from 'class-validator';
 
-export function IsInReportingPeriodRange(
+export function ArrayMaxLength(
+  maxLength: number,
   validationOptions?: ValidationOptions,
 ) {
   return function(object: Object, propertyName: string) {
     registerDecorator({
-      name: 'isInReportingPeriodRange',
+      name: 'arrayMaxLength',
       target: object.constructor,
       propertyName: propertyName,
       options: validationOptions,
       validator: {
         validate(value: any, args: ValidationArguments) {
-          if (value) {
-            const reportingPeriod = value.split(' Q');
-            return isInReportingPeriodRange(
-              reportingPeriod[0],
-              reportingPeriod[1],
-            );
-          }
-          return true;
+          return value.length <= maxLength;
         },
       },
     });


### PR DESCRIPTION
## Pull Request

```
Added reusable validation pipe for max array length
Added validation for number of selected reporting periods to not exceed 4 

```
