### PR TITLE
node-modules-cache-patch-1

### DIFF
--- a/manifest.yml
+++ b/manifest.yml
@@ -7,6 +7,7 @@ applications:
       - nodejs_buildpack
     env:
       OPTIMIZE_MEMORY: true
+      NODE_MODULES_CACHE: false
       EASEY_EMISSIONS_API_HOST: ((host))
       EASEY_EMISSIONS_API_PORT: ((port))
       EASEY_EMISSIONS_API_PATH: ((path))


### PR DESCRIPTION
checking to see if setting NODE_MODULES_CACHE to false will resolve the yarn offline cache issue
