### PR TITLE
feature/4881 Implement Delete Command and Update Dates for Emissions File Import

### DIFF
--- a/src/daily-calibration-workspace/daily-calibration.service.ts
+++ b/src/daily-calibration-workspace/daily-calibration.service.ts
@@ -51,6 +51,8 @@ export class DailyCalibrationWorkspaceService {
       this.repository.create({
         ...parameters,
         id: randomUUID(),
+        addDate: new Date(),
+        updateDate: new Date(),
       }),
     );
 

--- a/src/daily-emission-workspace/daily-emission-workspace.service.spec.ts
+++ b/src/daily-emission-workspace/daily-emission-workspace.service.spec.ts
@@ -58,6 +58,8 @@ describe('DailyEmissionWorkspaceService', () => {
       // @ts-expect-error use as mock
       jest.spyOn(repository, 'create').mockResolvedValue(dailyEmission);
       jest.spyOn(repository, 'save').mockResolvedValue(dailyEmission);
+      jest.spyOn(repository, 'delete').mockResolvedValue(undefined);
+
 
       await expect(
         service.import({

--- a/src/daily-emission-workspace/daily-emission-workspace.service.ts
+++ b/src/daily-emission-workspace/daily-emission-workspace.service.ts
@@ -8,6 +8,8 @@ import { ImportIdentifiers } from '../emissions-workspace/emissions.service';
 import { DailyEmissionImportDTO } from '../dto/daily-emission.dto';
 import { DailyEmissionMap } from '../maps/daily-emission.map';
 import { hasArrayValues } from '../utils/utils';
+import { DeleteResult, FindConditions } from 'typeorm';
+import { DailyEmission } from '../entities/workspace/daily-emission.entity';
 
 export type DailyEmissionWorkspaceCreate = DailyEmissionImportDTO & {
   reportingPeriodId: number;
@@ -22,6 +24,12 @@ export class DailyEmissionWorkspaceService {
     private readonly repository: DailyEmissionWorkspaceRepository,
     private readonly dailyFuelWorkspaceService: DailyFuelWorkspaceService,
   ) {}
+
+  async delete(
+    criteria: FindConditions<DailyEmission>,
+  ): Promise<DeleteResult> {
+    return this.repository.delete(criteria);
+  }
 
   async export(monitoringLocationIds: string[], params: EmissionsParamsDTO) {
     const dailyEmissionData = await exportDailyEmissionData({
@@ -49,6 +57,7 @@ export class DailyEmissionWorkspaceService {
   }
 
   async import(data: DailyEmissionWorkspaceCreate) {
+    this.delete({monitoringLocationId: data.monitoringLocationId, reportingPeriodId: data.reportingPeriodId})
     const dailyEmission = await this.repository.save(
       this.repository.create({
         id: randomUUID(),
@@ -61,6 +70,8 @@ export class DailyEmissionWorkspaceService {
         sorbentRelatedMassEmissions: data.sorbentRelatedMassEmissions,
         unadjustedDailyEmissions: data.unadjustedDailyEmissions,
         totalCarbonBurned: data.totalCarbonBurned,
+        addDate: new Date(),
+        updateDate: new Date(),
       }),
     );
 

--- a/src/daily-fuel-workspace/daily-fuel-workspace.service.ts
+++ b/src/daily-fuel-workspace/daily-fuel-workspace.service.ts
@@ -38,7 +38,8 @@ export class DailyFuelWorkspaceService {
         fuelCarbonBurned: data.fuelCarbonBurned,
         reportingPeriodId: data.reportingPeriodId,
         monitoringLocationId: data.monitoringLocationId,
-        addDate: new Date().toISOString(),
+        addDate: new Date(),
+        updateDate: new Date(),
         userId: data.identifiers.userId,
       }),
     );

--- a/src/daily-test-summary-workspace/daily-test-summary.service.spec.ts
+++ b/src/daily-test-summary-workspace/daily-test-summary.service.spec.ts
@@ -61,6 +61,7 @@ describe('Daily Summary Workspace Service', () => {
     const mappedValues = await Promise.all(promises);
 
     jest.spyOn(repository, 'export').mockResolvedValue(mockedValues);
+    jest.spyOn(repository, 'delete').mockResolvedValue(undefined);
 
     await expect(
       dailyTestSummaryService.getDailyTestSummariesByLocationIds(
@@ -73,7 +74,7 @@ describe('Daily Summary Workspace Service', () => {
   });
 
   it('should delete a record', async function() {
-    await expect(dailyTestSummaryService.delete('123')).resolves.toEqual(
+    await expect(dailyTestSummaryService.delete({ monitoringLocationId: '123', reportingPeriodId: 2 })).resolves.toEqual(
       undefined,
     );
   });

--- a/src/daily-test-summary-workspace/daily-test-summary.service.ts
+++ b/src/daily-test-summary-workspace/daily-test-summary.service.ts
@@ -7,12 +7,13 @@ import {
 import { DailyCalibrationWorkspaceService } from '../daily-calibration-workspace/daily-calibration.service';
 import { DailyTestSummaryMap } from '../maps/daily-test-summary.map';
 import { DailyTestSummaryWorkspaceRepository } from './daily-test-summary.repository';
-import { DeleteResult } from 'typeorm';
+import { DeleteResult, FindConditions } from 'typeorm';
 import { randomUUID } from 'crypto';
 import { DailyCalibrationImportDTO } from '../dto/daily-calibration.dto';
 import { EmissionsParamsDTO } from '../dto/emissions.params.dto';
 import { isUndefinedOrNull } from '../utils/utils';
 import { ImportIdentifiers } from '../emissions-workspace/emissions.service';
+import { DailyTestSummary } from '../entities/workspace/daily-test-summary.entity';
 
 export type DailyTestSummaryCreate = DailyTestSummaryImportDTO & {
   reportingPeriodId: number;
@@ -41,8 +42,10 @@ export class DailyTestSummaryWorkspaceService {
     return this.map.many(results);
   }
 
-  async delete(id: string): Promise<DeleteResult> {
-    return this.repository.delete({ id });
+  async delete(
+    criteria: FindConditions<DailyTestSummary>,
+  ): Promise<DeleteResult> {
+    return this.repository.delete(criteria);
   }
 
   async export(
@@ -73,6 +76,7 @@ export class DailyTestSummaryWorkspaceService {
   async import(
     parameters: DailyTestSummaryCreate,
   ): Promise<DailyTestSummaryDTO> {
+    this.delete({monitoringLocationId: parameters.monitoringLocationId, reportingPeriodId: parameters.reportingPeriodId})
     const result = await this.repository.save(
       this.repository.create({
         ...parameters,
@@ -83,6 +87,8 @@ export class DailyTestSummaryWorkspaceService {
           ],
         componentId:
           parameters?.identifiers?.components?.[parameters.componentId],
+        addDate: new Date(),
+        updateDate: new Date(),
       }),
     );
 

--- a/src/derived-hourly-value-workspace/derived-hourly-value-workspace.service.ts
+++ b/src/derived-hourly-value-workspace/derived-hourly-value-workspace.service.ts
@@ -45,6 +45,8 @@ export class DerivedHourlyValueWorkspaceService {
         hourId,
         rptPeriodId: reportingPeriodId,
         monitorLocationId: monitoringLocationId,
+        addDate: new Date(),
+        updateDate: new Date(),
       }),
     );
   }

--- a/src/emissions-workspace/emissions.service.ts
+++ b/src/emissions-workspace/emissions.service.ts
@@ -9,7 +9,6 @@ import { EmissionsMap } from '../maps/emissions.map';
 import { EmissionsWorkspaceRepository } from './emissions.repository';
 import { DailyTestSummaryWorkspaceService } from '../daily-test-summary-workspace/daily-test-summary.service';
 import { PlantRepository } from '../plant/plant.repository';
-import { EmissionEvaluation } from '../entities/emission-evaluation.entity';
 import { DailyTestSummaryDTO } from '../dto/daily-test-summary.dto';
 import { HourlyOperatingWorkspaceService } from '../hourly-operating-workspace/hourly-operating.service';
 import {
@@ -30,6 +29,7 @@ import { SorbentTrapWorkspaceService } from '../sorbent-trap-workspace/sorbent-t
 import { WeeklyTestSummaryWorkspaceService } from '../weekly-test-summary-workspace/weekly-test-summary.service';
 import { Nsps4tSummaryWorkspaceService } from '../nsps4t-summary-workspace/nsps4t-summary-workspace.service';
 import { WeeklyTestSummaryDTO } from '../dto/weekly-test-summary.dto';
+import { EmissionEvaluation } from '../entities/workspace/emission-evaluation.entity';
 
 // Import Identifier: Table Id
 export type ImportIdentifiers = {
@@ -230,7 +230,8 @@ export class EmissionsWorkspaceService {
         this.repository.create({
           monitorPlanId,
           reportingPeriodId,
-          evalStatusCd: 'EVAL'
+          evalStatusCd: 'EVAL',
+          lastUpdated: new Date(),
         }),
       );
         

--- a/src/hourly-fuel-flow-workspace/hourly-fuel-flow-workspace.service.ts
+++ b/src/hourly-fuel-flow-workspace/hourly-fuel-flow-workspace.service.ts
@@ -63,6 +63,8 @@ export class HourlyFuelFlowWorkspaceService {
           identifiers.monitoringSystems?.[data.monitoringSystemId],
         monitoringLocationId: monitoringLocationId,
         reportingPeriodId: reportingPeriodId,
+        addDate: new Date(),
+        updateDate: new Date(),
       }),
     );
 

--- a/src/hourly-gas-flow-meter-workspace/hourly-gas-flow-meter.service.ts
+++ b/src/hourly-gas-flow-meter-workspace/hourly-gas-flow-meter.service.ts
@@ -40,6 +40,8 @@ export class HourlyGasFlowMeterWorkspaceService {
         avgHourlySamplingRate: data.avgHourlySamplingRate,
         samplingRateUom: data.samplingRateUom,
         hourlySfsrRatio: data.hourlySfsrRatio,
+        addDate: new Date(),
+        updateDate: new Date(),
       }),
     );
   }

--- a/src/hourly-operating-workspace/hourly-operating.service.spec.ts
+++ b/src/hourly-operating-workspace/hourly-operating.service.spec.ts
@@ -201,6 +201,7 @@ describe('HourlyOperatingWorskpaceService', () => {
 
       const mappedMock = await map.one(hourlyOpImport[0]);
       jest.spyOn(repository, 'save').mockResolvedValue(hourlyOpImport[0]);
+      jest.spyOn(repository, 'delete').mockResolvedValue(undefined);
 
       await expect(
         service.import(

--- a/src/hourly-operating-workspace/hourly-operating.service.ts
+++ b/src/hourly-operating-workspace/hourly-operating.service.ts
@@ -1,6 +1,6 @@
 import { HttpStatus, Injectable } from '@nestjs/common';
 import { LoggingException } from '@us-epa-camd/easey-common/exceptions';
-import { DeleteResult } from 'typeorm';
+import { DeleteResult, FindConditions } from 'typeorm';
 import { randomUUID } from 'crypto';
 
 import { HourlyOperatingMap } from '../maps/hourly-operating.map';
@@ -19,6 +19,7 @@ import { HourlyGasFlowMeterWorkspaceService } from '../hourly-gas-flow-meter-wor
 import { ImportIdentifiers } from '../emissions-workspace/emissions.service';
 import { EmissionsImportDTO } from '../dto/emissions.dto';
 import { HourlyFuelFlowWorkspaceService } from '../hourly-fuel-flow-workspace/hourly-fuel-flow-workspace.service';
+import { HrlyOpData } from '../entities/workspace/hrly-op-data.entity';
 
 export type HourlyOperatingCreate = HourlyOperatingImportDTO & {
   reportingPeriodId: number;
@@ -104,18 +105,23 @@ export class HourlyOperatingWorkspaceService {
     return hourlyOperating;
   }
 
-  async delete(id: string): Promise<DeleteResult> {
-    return this.repository.delete({ id });
+  async delete(
+    criteria: FindConditions<HrlyOpData>,
+  ): Promise<DeleteResult> {
+    return this.repository.delete(criteria);
   }
 
   async import(
     emissionsImport: EmissionsImportDTO,
     data: HourlyOperatingCreate,
   ): Promise<HourlyOperatingDTO> {
+    this.delete({monitoringLocationId: data.monitoringLocationId, reportingPeriodId: data.reportingPeriodId})
     const result = await this.repository.save(
       this.repository.create({
         ...data,
         id: randomUUID(),
+        addDate: new Date(),
+        updateDate: new Date(),
       }),
     );
 

--- a/src/hourly-parameter-fuel-flow-workspace/hourly-parameter-fuel-flow-workspace.service.ts
+++ b/src/hourly-parameter-fuel-flow-workspace/hourly-parameter-fuel-flow-workspace.service.ts
@@ -44,6 +44,8 @@ export class HourlyParameterFuelFlowWorkspaceService {
         parameterUomCode: data.parameterUomCode,
         monitoringLocationId: monitoringLocationId,
         reportingPeriodId: reportingPeriodId,
+        addDate: new Date(),
+        updateDate: new Date(),
       }),
     );
   }

--- a/src/mats-derived-hourly-value-workspace/mats-derived-hourly-value.service.ts
+++ b/src/mats-derived-hourly-value-workspace/mats-derived-hourly-value.service.ts
@@ -36,6 +36,8 @@ export class MatsDerivedHourlyValueWorkspaceService {
       hourId,
       monitoringLocationId,
       reportingPeriodId,
+      addDate: new Date(),
+      updateDate: new Date(),
     };
     return this.repository.save(this.repository.create(o));
   }

--- a/src/mats-monitor-hourly-value-workspace/mats-monitor-hourly-value.service.ts
+++ b/src/mats-monitor-hourly-value-workspace/mats-monitor-hourly-value.service.ts
@@ -41,6 +41,8 @@ export class MatsMonitorHourlyValueWorkspaceService {
         hourId,
         monitoringLocationId: monitoringLocationId,
         reportingPeriodId: reportingPeriodId,
+        addDate: new Date(),
+        updateDate: new Date(),
       }),
     );
   }

--- a/src/monitor-hourly-value-workspace/monitor-hourly-value.service.ts
+++ b/src/monitor-hourly-value-workspace/monitor-hourly-value.service.ts
@@ -42,6 +42,8 @@ export class MonitorHourlyValueWorkspaceService {
         monitoringLocationId: monitoringLocationId,
         reportingPeriodId: reportingPeriodId,
         hourId,
+        addDate: new Date(),
+        updateDate: new Date(),
       }),
     );
   }

--- a/src/nsps4t-annual-functions/import-nsps4t-annual-data.ts
+++ b/src/nsps4t-annual-functions/import-nsps4t-annual-data.ts
@@ -30,7 +30,8 @@ export const importNsps4tAnnualData = async ({
       monitoringLocationId: data.monitoringLocationId,
       reportingPeriodId: data.reportingPeriodId,
       userId: data.identifiers?.userId,
-      addDate: new Date().toISOString(),
+      addDate: new Date(),
+      updateDate: new Date(),
     }),
   );
 };

--- a/src/nsps4t-compliance-period-functions/import-nsps4t-compliance-period-data.ts
+++ b/src/nsps4t-compliance-period-functions/import-nsps4t-compliance-period-data.ts
@@ -36,7 +36,8 @@ export const importNsps4tCompliancePeriodData = async ({
       monitoringLocationId: data.monitoringLocationId,
       reportingPeriodId: data.reportingPeriodId,
       userId: data.identifiers?.userId,
-      addDate: new Date().toISOString(),
+      addDate: new Date(),
+      updateDate: new Date(),
     }),
   );
 };

--- a/src/nsps4t-summary-functions/import-nsps4t-summary-data.spec.ts
+++ b/src/nsps4t-summary-functions/import-nsps4t-summary-data.spec.ts
@@ -26,6 +26,7 @@ describe('ImportNsps4tSummaryData', () => {
     // @ts-expect-error force as undefined
     jest.spyOn(repository, 'create').mockResolvedValue(undefined);
     jest.spyOn(repository, 'save').mockResolvedValue(undefined);
+    jest.spyOn(repository, 'delete').mockResolvedValue(undefined);
 
     await Promise.all(
       imports.map(data => {

--- a/src/nsps4t-summary-functions/import-nsps4t-summary-data.ts
+++ b/src/nsps4t-summary-functions/import-nsps4t-summary-data.ts
@@ -31,7 +31,8 @@ export const importNsps4tSummaryData = async ({
       monitoringLocationId: data.monitoringLocationId,
       reportingPeriodId: data.reportingPeriodId,
       userId: data.identifiers?.userId,
-      addDate: new Date().toISOString(),
+      addDate: new Date(),
+      updateDate: new Date(),
     }),
   );
 };

--- a/src/nsps4t-summary-workspace/nsps4t-summary-workspace.service.spec.ts
+++ b/src/nsps4t-summary-workspace/nsps4t-summary-workspace.service.spec.ts
@@ -79,6 +79,7 @@ describe('Nsps4tSummaryWorkspaceNewService', () => {
     jest.spyOn(importNsps4tSummaryData, 'importNsps4tSummaryData').mockResolvedValue(entityMocks[0]);
     jest.spyOn(annualService, 'import').mockResolvedValue(entityMocks[0].nsps4tAnnualData[0]);
     jest.spyOn(compliancePeriodService, 'import').mockResolvedValue(entityMocks[0].nsps4tCompliancePeriodData[0]);
+    jest.spyOn(repository, 'delete').mockResolvedValue(undefined);
 
     await expect(
       service.import(

--- a/src/nsps4t-summary-workspace/nsps4t-summary-workspace.service.ts
+++ b/src/nsps4t-summary-workspace/nsps4t-summary-workspace.service.ts
@@ -9,6 +9,8 @@ import { Injectable } from '@nestjs/common';
 import { arrayPushCreate, hasArrayValues } from '../utils/utils';
 import { exportNsps4tSummaryData } from '../nsps4t-summary-functions/export-nsps4t-summary-data';
 import { EmissionsParamsDTO } from '../dto/emissions.params.dto';
+import { DeleteResult, FindConditions } from 'typeorm';
+import { Nsps4tSummary } from '../entities/workspace/nsps4t-summary.entity';
 
 @Injectable()
 export class Nsps4tSummaryWorkspaceService {
@@ -17,6 +19,12 @@ export class Nsps4tSummaryWorkspaceService {
     private readonly nsps4tAnnualService: Nsps4tAnnualWorkspaceService,
     private readonly nsps4tCompliancePeriodService: Nsps4tCompliancePeriodWorkspaceService,
   ) {}
+
+  async delete(
+    criteria: FindConditions<Nsps4tSummary>,
+  ): Promise<DeleteResult> {
+    return this.repository.delete(criteria);
+  }
 
   async export(monitoringLocationIds: string[], params: EmissionsParamsDTO) {
     const nsps4tSummaryData = await exportNsps4tSummaryData({
@@ -52,6 +60,7 @@ export class Nsps4tSummaryWorkspaceService {
   }
 
   async import(data: Nsps4tSummaryDataCreate) {
+    this.delete({monitoringLocationId: data.monitoringLocationId, reportingPeriodId: data.reportingPeriodId})
     const nsps4tSummaryData = await importNsps4tSummaryData({
       data,
       repository: this.repository,

--- a/src/sampling-train-functions/import-sampling-train-data.ts
+++ b/src/sampling-train-functions/import-sampling-train-data.ts
@@ -41,6 +41,8 @@ export const importSamplingTrainData = async ({
       trainQaStatusCode: data.trainQaStatusCode,
       sampleDamageExplanation: data.sampleDamageExplanation,
       userId: data.identifiers?.userId,
+      addDate: new Date(),
+      updateDate: new Date(),
     }),
   );
 };

--- a/src/sorbent-trap-functions/import-sorbent-trap-data.spec.ts
+++ b/src/sorbent-trap-functions/import-sorbent-trap-data.spec.ts
@@ -20,6 +20,7 @@ describe('ImportSorbentTrapData', () => {
     // @ts-expect-error force as undefined
     jest.spyOn(repository, 'create').mockResolvedValue(undefined);
     jest.spyOn(repository, 'save').mockResolvedValue(undefined);
+    jest.spyOn(repository, 'delete').mockResolvedValue(undefined);
 
     await Promise.all(
       importReturn.map(data => {

--- a/src/sorbent-trap-functions/import-sorbent-trap-data.ts
+++ b/src/sorbent-trap-functions/import-sorbent-trap-data.ts
@@ -35,6 +35,8 @@ export const importSorbentTrapData = async ({
     userId: data.identifiers?.userId,
     apsCode: data.apsCode,
     rataIndicator: data.rataIndicator,
+    addDate: new Date(),
+    updateDate: new Date(),
   });
 
   return repository.save(sorbentTrap);

--- a/src/sorbent-trap-workspace/sorbent-trap-workspace.service.spec.ts
+++ b/src/sorbent-trap-workspace/sorbent-trap-workspace.service.spec.ts
@@ -55,6 +55,7 @@ describe('SorbentTrapWorkspaceService', () => {
   });
 
   it('should successfully import', async function () {
+    jest.spyOn(service, 'delete').mockResolvedValue(undefined);
     const mockedValues = genSorbentTrap<SorbentTrap>(1, { include: ['samplingTrains'], samplingTrainAmount: 1 });
 
     // need to massage the data to make it look like import dto
@@ -72,5 +73,4 @@ describe('SorbentTrapWorkspaceService', () => {
       ),
     ).resolves.toEqual(mockedValues[0]);
   });
-
 });

--- a/src/sorbent-trap-workspace/sorbent-trap-workspace.service.ts
+++ b/src/sorbent-trap-workspace/sorbent-trap-workspace.service.ts
@@ -8,6 +8,8 @@ import {
   importSorbentTrapData,
   SorbentTrapWorkspaceCreate,
 } from '../sorbent-trap-functions/import-sorbent-trap-data';
+import { DeleteResult, FindConditions } from 'typeorm';
+import { SorbentTrap } from '../entities/workspace/sorbent-trap.entity';
 
 @Injectable()
 export class SorbentTrapWorkspaceService {
@@ -15,6 +17,12 @@ export class SorbentTrapWorkspaceService {
     private readonly repository: SorbentTrapWorkspaceRepository,
     private readonly samplingTrainService: SamplingTrainWorkspaceService,
   ) {}
+
+  async delete(
+    criteria: FindConditions<SorbentTrap>,
+  ): Promise<DeleteResult> {
+    return this.repository.delete(criteria);
+  }
 
   async export(monitoringLocationIds: string[], params: EmissionsParamsDTO) {
     const sorbentTrapData = await exportSorbentTrapData({
@@ -39,7 +47,9 @@ export class SorbentTrapWorkspaceService {
     return sorbentTrapData;
   }
 
-  async import(data: SorbentTrapWorkspaceCreate) {
+  async import(data: SorbentTrapWorkspaceCreate) 
+  {
+    this.delete({monitoringLocationId: data.monitoringLocationId, reportingPeriodId: data.reportingPeriodId})
     const sorbentTrap = await importSorbentTrapData({
       data,
       repository: this.repository,

--- a/src/summary-value-workspace/summary-value.service.spec.ts
+++ b/src/summary-value-workspace/summary-value.service.spec.ts
@@ -44,6 +44,7 @@ describe('Summary Value Workspace Service Test', () => {
 
   describe('Summary Value Import', () => {
     it('should successfully import a summary value record', async () => {
+      jest.spyOn(service, 'delete').mockResolvedValue(undefined);
       const generatedData = genSummaryValueImportDto(1)[0];
       const importData: SummaryValueCreate = {
         ...generatedData,

--- a/src/weekly-system-integrity-workspace/weekly-system-integrity.service.ts
+++ b/src/weekly-system-integrity-workspace/weekly-system-integrity.service.ts
@@ -47,6 +47,8 @@ export class WeeklySystemIntegrityWorkspaceService {
         measuredValue: data.measuredValue,
         apsIndicator: data.apsIndicator,
         systemIntegrityError: data.systemIntegrityError,
+        addDate: new Date(),
+        updateDate: new Date(),
       }),
     );
   }

--- a/src/weekly-test-summary-workspace/weekly-test-summary.service.spec.ts
+++ b/src/weekly-test-summary-workspace/weekly-test-summary.service.spec.ts
@@ -81,6 +81,7 @@ describe('--WeeklyTestSummaryWorkspaceService--', () => {
       const mappedMock = await map.one(generatedData[0]);
 
       jest.spyOn(repository, 'save').mockResolvedValue(generatedData[0]);
+      jest.spyOn(service, 'delete').mockResolvedValue(undefined);
       await expect(
         service.import(
           (generatedData[0] as unknown) as WeeklyTestSummaryCreate,

--- a/src/weekly-test-summary-workspace/weekly-test-summary.service.ts
+++ b/src/weekly-test-summary-workspace/weekly-test-summary.service.ts
@@ -10,6 +10,8 @@ import {
 } from '../dto/weekly-test-summary.dto';
 import { WeeklySystemIntegrityWorkspaceService } from '../weekly-system-integrity-workspace/weekly-system-integrity.service';
 import { ImportIdentifiers } from '../emissions-workspace/emissions.service';
+import { DeleteResult, FindConditions } from 'typeorm';
+import { WeeklyTestSummary } from '../entities/workspace/weekly-test-summary.entity';
 
 export type WeeklyTestSummaryCreate = WeeklyTestSummaryImportDTO & {
   reportingPeriodId: number;
@@ -24,6 +26,13 @@ export class WeeklyTestSummaryWorkspaceService {
     private readonly repository: WeeklyTestSummaryWorkspaceRepository,
     private readonly weeklySystemIntegrityService: WeeklySystemIntegrityWorkspaceService,
   ) {}
+
+  async delete(
+    criteria: FindConditions<WeeklyTestSummary>,
+  ): Promise<DeleteResult> {
+    return this.repository.delete(criteria);
+  }
+  
   async getWeeklyTestSummariesByLocationIds(
     monitoringLocationIds: string[],
     params: EmissionsParamsDTO,
@@ -61,11 +70,14 @@ export class WeeklyTestSummaryWorkspaceService {
   }
 
   async import(data: WeeklyTestSummaryCreate): Promise<WeeklyTestSummaryDTO> {
+    this.delete({monitoringLocationId: data.monitoringLocationId, reportingPeriodId: data.reportingPeriodId})
     const weeklyTestSummary = await this.repository.save(
       this.repository.create({
         ...data,
         id: randomUUID(),
         componentId: data.identifiers?.components?.[data.componentId],
+        addDate: new Date(),
+        updateDate: new Date(),
       }),
     );
 


### PR DESCRIPTION
## Pull Request

```
- Added functionality to delete duplicate children records during import
- Updated values of addDate and updateDate during import for all datatypes 

```
