### PR TITLE
Feat/5395 import daily backstop data

### DIFF
--- a/src/daily-backstop-workspace/daily-backstop.module.ts
+++ b/src/daily-backstop-workspace/daily-backstop.module.ts
@@ -1,0 +1,15 @@
+import { Module } from '@nestjs/common';
+import { TypeOrmModule } from '@nestjs/typeorm';
+import { DailyBackstopMap } from '../maps/daily-backstop.map';
+import { DailyBackstopWorkspaceService } from './daily-backstop.service';
+import { BulkLoadModule } from '@us-epa-camd/easey-common/bulk-load';
+
+@Module({
+  imports: [
+    BulkLoadModule,
+  ],
+  controllers: [],
+  providers: [DailyBackstopWorkspaceService, DailyBackstopMap],
+  exports: [DailyBackstopWorkspaceService, DailyBackstopMap],
+})
+export class DailyBackstopWorkspaceModule {}

--- a/src/daily-backstop-workspace/daily-backstop.module.ts
+++ b/src/daily-backstop-workspace/daily-backstop.module.ts
@@ -1,5 +1,4 @@
 import { Module } from '@nestjs/common';
-import { TypeOrmModule } from '@nestjs/typeorm';
 import { DailyBackstopMap } from '../maps/daily-backstop.map';
 import { DailyBackstopWorkspaceService } from './daily-backstop.service';
 import { BulkLoadModule } from '@us-epa-camd/easey-common/bulk-load';

--- a/src/daily-backstop-workspace/daily-backstop.service.spec.ts
+++ b/src/daily-backstop-workspace/daily-backstop.service.spec.ts
@@ -1,0 +1,56 @@
+import { Test } from '@nestjs/testing';
+import { BulkLoadService } from "@us-epa-camd/easey-common/bulk-load";
+import { DailyBackstopWorkspaceService } from "./daily-backstop.service";
+import { ConfigService } from '@nestjs/config';
+import { EmissionsImportDTO } from '../dto/emissions.dto';
+import { genDailyBackstopImportDto } from '../../test/object-generators/daily-backstop-dto';
+import { ImportIdentifiers } from '../emissions-workspace/emissions.service';
+
+
+describe('Daily Backstop Workspace Service Test', () => {
+    let service: DailyBackstopWorkspaceService;
+    let bulkLoadService: BulkLoadService;
+
+    beforeEach(async () => {
+        const module = await Test.createTestingModule({
+            providers: [
+                DailyBackstopWorkspaceService,
+                BulkLoadService,
+                ConfigService,
+            ],
+        }).compile();
+
+        service = module.get(DailyBackstopWorkspaceService);
+        bulkLoadService = module.get(BulkLoadService);
+    });
+
+    describe('Daily Backstop Import', () => {
+        it('should successfully import a daily record', async () => {
+            const generatedData = genDailyBackstopImportDto(1);
+
+            // @ts-expect-error use as mock
+            jest.spyOn(bulkLoadService, 'startBulkLoader').mockResolvedValue({
+                writeObject: jest.fn(),
+                complete: jest.fn(),
+                finished: Promise.resolve(true),
+            });
+
+            const emissionsDto = new EmissionsImportDTO();
+            emissionsDto.dailyBackstopData = generatedData;
+
+            const locations = [{ unit: { name: 'a' }, id: 1 }];
+            emissionsDto.dailyBackstopData[0].unitId = 'a';
+            const identifiers = ({
+                components: [],
+                monitorFormulas: [],
+                monitoringSystems: [],
+                userId: '',
+            } as unknown) as ImportIdentifiers;
+
+            await expect(service.import(emissionsDto, locations, '', identifiers, ''))
+                .resolves;
+        });
+    });
+
+
+});

--- a/src/daily-backstop-workspace/daily-backstop.service.ts
+++ b/src/daily-backstop-workspace/daily-backstop.service.ts
@@ -1,0 +1,12 @@
+import { Injectable } from "@nestjs/common";
+import { ImportIdentifiers } from "../emissions-workspace/emissions.service";
+
+export type DailyBackstopCreate = & {
+    reportingPeriodId: number;
+    monitoringLocationId: string;
+    identifiers: ImportIdentifiers;
+};
+
+@Injectable()
+export class SummaryValueWorkspaceService {
+}

--- a/src/daily-backstop-workspace/daily-backstop.service.ts
+++ b/src/daily-backstop-workspace/daily-backstop.service.ts
@@ -1,9 +1,7 @@
 import { Injectable } from "@nestjs/common";
 import { ImportIdentifiers } from "../emissions-workspace/emissions.service";
-// import { DailyBackstopMap } from "../maps/daily-backstop.map";
 import { BulkLoadService } from "@us-epa-camd/easey-common/bulk-load";
 import { EmissionsImportDTO } from "../dto/emissions.dto";
-import { randomUUID } from 'crypto';
 
 export type DailyBackstopCreate = & {
     reportingPeriodId: number;
@@ -15,7 +13,6 @@ export type DailyBackstopCreate = & {
 export class DailyBackstopWorkspaceService {
 
     constructor(
-        // private readonly map: DailyBackstopMap,
         private readonly bulkLoadService: BulkLoadService,    
     ){}
 

--- a/src/daily-backstop-workspace/daily-backstop.service.ts
+++ b/src/daily-backstop-workspace/daily-backstop.service.ts
@@ -36,7 +36,6 @@ export class DailyBackstopWorkspaceService {
         const bulkLoadStream = await this.bulkLoadService.startBulkLoader(
           'camdecmpswks.daily_backstop',
           [
-            'unit_id',
             'op_date',
             'daily_noxm',
             'daily_hit',
@@ -57,7 +56,6 @@ export class DailyBackstopWorkspaceService {
           )[0].id;
         
           const {
-            unitId,
             date,
             dailyNOxEmissions,
             dailyHeatInput,
@@ -67,7 +65,6 @@ export class DailyBackstopWorkspaceService {
           } = dailyBackstopDatum;
     
           bulkLoadStream.writeObject({
-            unitId,
             date,
             dailyNOxEmissions,
             dailyHeatInput,

--- a/src/daily-backstop-workspace/daily-backstop.service.ts
+++ b/src/daily-backstop-workspace/daily-backstop.service.ts
@@ -2,6 +2,7 @@ import { Injectable } from "@nestjs/common";
 import { ImportIdentifiers } from "../emissions-workspace/emissions.service";
 import { BulkLoadService } from "@us-epa-camd/easey-common/bulk-load";
 import { EmissionsImportDTO } from "../dto/emissions.dto";
+import { MonitorLocation } from "../entities/workspace/monitor-location.entity";
 
 export type DailyBackstopCreate = & {
     reportingPeriodId: number;
@@ -33,6 +34,7 @@ export class DailyBackstopWorkspaceService {
         const bulkLoadStream = await this.bulkLoadService.startBulkLoader(
           'camdecmpswks.daily_backstop',
           [
+            'unit_id',
             'op_date',
             'daily_noxm',
             'daily_hit',
@@ -48,9 +50,9 @@ export class DailyBackstopWorkspaceService {
         );
     
         for (const dailyBackstopDatum of emissionsImport.dailyBackstopData) {
-          const monitoringLocationId = monitoringLocations.filter(location => 
+          const monitoringLocation: MonitorLocation = monitoringLocations.filter(location => 
               location.unit?.name === dailyBackstopDatum.unitId 
-          )[0].id;
+          )[0];
         
           const {
             date,
@@ -62,13 +64,14 @@ export class DailyBackstopWorkspaceService {
           } = dailyBackstopDatum;
     
           bulkLoadStream.writeObject({
+            unitId: monitoringLocation?.unit?.id ?? null,
             date,
             dailyNOxEmissions,
             dailyHeatInput,
             dailyAverageNOxRate,
             dailyNOxExceedence,
             cumulativeOSNOxExceedence,
-            monitoringLocationId,
+            monitoringLocationId: monitoringLocation?.id ?? null,
             reportingPeriodId,
             userId: identifiers?.userId,
             addDate: currentTime,

--- a/src/dto/daily-backstop.dto.ts
+++ b/src/dto/daily-backstop.dto.ts
@@ -1,17 +1,9 @@
 import {
 IsOptional,
 IsString,
-ValidateNested,
 IsNumber,
 IsDateString,
-ValidationArguments,
 } from 'class-validator';
-import { Type } from 'class-transformer';
-import { DailyFuelDTO, DailyFuelImportDTO } from './daily-fuel.dto';
-import { IsValidCode } from '@us-epa-camd/easey-common/pipes';
-import { ImportCodeErrorMessage } from '../utils/validator.const';
-import { ParameterCode } from '../entities/parameter-code.entity';
-
 
 export class DailyBackstopBaseDTO {
     @IsString()
@@ -25,11 +17,7 @@ export class DailyBackstopBaseDTO {
   
     @IsNumber()
     dailyHeatInput?: number;
-  
-    @IsOptional()
-    @IsNumber()
-    sorbentRelatedMassEmissions?: number;
-  
+    
     @IsNumber()
     dailyAverageNOxRate?: number;
   

--- a/src/dto/daily-backstop.dto.ts
+++ b/src/dto/daily-backstop.dto.ts
@@ -1,5 +1,4 @@
 import {
-IsOptional,
 IsString,
 IsNumber,
 IsDateString,

--- a/src/dto/daily-backstop.dto.ts
+++ b/src/dto/daily-backstop.dto.ts
@@ -1,0 +1,54 @@
+import {
+IsOptional,
+IsString,
+ValidateNested,
+IsNumber,
+IsDateString,
+ValidationArguments,
+} from 'class-validator';
+import { Type } from 'class-transformer';
+import { DailyFuelDTO, DailyFuelImportDTO } from './daily-fuel.dto';
+import { IsValidCode } from '@us-epa-camd/easey-common/pipes';
+import { ImportCodeErrorMessage } from '../utils/validator.const';
+import { ParameterCode } from '../entities/parameter-code.entity';
+
+
+export class DailyBackstopBaseDTO {
+    @IsString()
+    unitId?: string;
+    
+    @IsDateString()
+    date: Date;
+  
+    @IsNumber()
+    dailyNOxEmissions?: number;
+  
+    @IsNumber()
+    dailyHeatInput?: number;
+  
+    @IsOptional()
+    @IsNumber()
+    sorbentRelatedMassEmissions?: number;
+  
+    @IsNumber()
+    dailyAverageNOxRate?: number;
+  
+    @IsNumber()
+    dailyNOxExceedence?: number;
+
+    @IsNumber()
+    cumulativeOSNOxExceedence?: number;
+  }
+
+export class DailyBackstopRecordDTO extends DailyBackstopBaseDTO{
+  id: string;
+  monitoringLocationId: string;
+  userId?: string;
+  addDate?: string;
+  updateDate?: string;
+  reportingPeriodId?: number;  
+}
+
+export class DailyBackstopImportDTO extends DailyBackstopBaseDTO {}
+
+export class DailyBackstopDTO extends DailyBackstopRecordDTO {}

--- a/src/dto/emissions.dto.ts
+++ b/src/dto/emissions.dto.ts
@@ -31,6 +31,7 @@ import {
   WeeklyTestSummaryImportDTO,
 } from './weekly-test-summary.dto';
 import { CheckCatalogService } from '@us-epa-camd/easey-common/check-catalog';
+import { DailyBackstopDTO } from './daily-backstop.dto';
 
 export class EmissionsBaseDTO {
   @DbLookup(
@@ -123,6 +124,10 @@ export class EmissionsImportDTO extends EmissionsBaseDTO {
   @ValidateNested({ each: true })
   @Type(() => Nsps4tSummaryImportDTO)
   nsps4tSummaryData: Nsps4tSummaryImportDTO[];
+
+  @ValidateNested({ each: true })
+  @Type(() => DailyBackstopDTO)
+  dailyBackstopData: DailyBackstopDTO[];
 }
 
 export class EmissionsDTO extends EmissionsRecordDTO {
@@ -157,6 +162,10 @@ export class EmissionsDTO extends EmissionsRecordDTO {
   @ValidateNested({ each: true })
   @Type(() => Nsps4tSummaryDTO)
   nsps4tSummaryData: Nsps4tSummaryDTO[];
+
+  @ValidateNested({ each: true })
+  @Type(() => DailyBackstopDTO)
+  dailyBackstopData: DailyBackstopDTO[];
 
   constructor(values: Object = {}) {
     super(values);

--- a/src/dto/emissions.dto.ts
+++ b/src/dto/emissions.dto.ts
@@ -31,7 +31,7 @@ import {
   WeeklyTestSummaryImportDTO,
 } from './weekly-test-summary.dto';
 import { CheckCatalogService } from '@us-epa-camd/easey-common/check-catalog';
-import { DailyBackstopDTO } from './daily-backstop.dto';
+import { DailyBackstopDTO, DailyBackstopImportDTO } from './daily-backstop.dto';
 
 export class EmissionsBaseDTO {
   @DbLookup(
@@ -127,7 +127,7 @@ export class EmissionsImportDTO extends EmissionsBaseDTO {
 
   @ValidateNested({ each: true })
   @Type(() => DailyBackstopDTO)
-  dailyBackstopData: DailyBackstopDTO[];
+  dailyBackstopData: DailyBackstopImportDTO[];
 }
 
 export class EmissionsDTO extends EmissionsRecordDTO {

--- a/src/emissions-workspace/emissions-checks.service.ts
+++ b/src/emissions-workspace/emissions-checks.service.ts
@@ -46,7 +46,8 @@ export class EmissionsChecksService {
       doesNotHaveData(payload.dailyTestSummaryData) &&
       doesNotHaveData(payload.hourlyOperatingData) &&
       doesNotHaveData(payload.longTermFuelFlowData) &&
-      doesNotHaveData(payload.nsps4tSummaryData)
+      doesNotHaveData(payload.nsps4tSummaryData) &&
+      doesNotHaveData(payload.dailyBackstopData)
     ) {
       this.throwIfErrors(['No data found in payload']);
     }

--- a/src/emissions-workspace/emissions.controller.spec.ts
+++ b/src/emissions-workspace/emissions.controller.spec.ts
@@ -85,6 +85,7 @@ import { LongTermFuelFlowWorkspaceRepository } from '../long-term-fuel-flow-work
 import { LongTermFuelFlowWorkspaceService } from '../long-term-fuel-flow-workspace/long-term-fuel-flow.service';
 import { LongTermFuelFlowMap } from '../maps/long-term-fuel-flow.map';
 import { BulkLoadModule } from '@us-epa-camd/easey-common/bulk-load';
+import { DailyBackstopWorkspaceModule } from '../daily-backstop-workspace/daily-backstop.module';
 
 describe('-- Emissions Controller --', () => {
   let controller: EmissionsWorkspaceController;
@@ -94,7 +95,7 @@ describe('-- Emissions Controller --', () => {
 
   beforeAll(async () => {
     const module = await Test.createTestingModule({
-      imports: [LoggerModule, HttpModule, BulkLoadModule],
+      imports: [LoggerModule, HttpModule, BulkLoadModule, DailyBackstopWorkspaceModule],
       controllers: [EmissionsWorkspaceController],
       providers: [
         DailyEmissionWorkspaceService,

--- a/src/emissions-workspace/emissions.module.ts
+++ b/src/emissions-workspace/emissions.module.ts
@@ -48,6 +48,7 @@ import { EmissionsReviewSubmitMap } from '../maps/emissions-review-submit.map';
 import { LongTermFuelFlowWorkspaceRepository } from '../long-term-fuel-flow-workspace/long-term-fuel-flow.repository';
 import { LongTermFuelFlowWorkspaceModule } from '../long-term-fuel-flow-workspace/long-term-fuel-flow.module';
 import { LongTermFuelFlowWorkspaceService } from '../long-term-fuel-flow-workspace/long-term-fuel-flow.service';
+import { DailyBackstopWorkspaceModule } from '../daily-backstop-workspace/daily-backstop.module';
 
 @Module({
   imports: [
@@ -79,6 +80,7 @@ import { LongTermFuelFlowWorkspaceService } from '../long-term-fuel-flow-workspa
     HourlyFuelFlowWorkspaceModule,
     SummaryValueWorkspaceModule,
     LongTermFuelFlowWorkspaceModule,
+    DailyBackstopWorkspaceModule,
   ],
   controllers: [EmissionsWorkspaceController],
   providers: [

--- a/src/emissions-workspace/emissions.service.spec.ts
+++ b/src/emissions-workspace/emissions.service.spec.ts
@@ -100,6 +100,7 @@ import { ReportingPeriod } from '../entities/workspace/reporting-period.entity';
 import { BulkLoadModule } from '@us-epa-camd/easey-common/bulk-load';
 import { MonitorLocation } from '../entities/monitor-location.entity';
 import { ConfigService } from '@nestjs/config';
+import { DailyBackstopWorkspaceModule } from '../daily-backstop-workspace/daily-backstop.module';
 
 describe('Emissions Workspace Service', () => {
   let dailyTestsummaryService: DailyTestSummaryWorkspaceService;
@@ -111,7 +112,7 @@ describe('Emissions Workspace Service', () => {
 
   beforeAll(async () => {
     const module: TestingModule = await Test.createTestingModule({
-      imports: [BulkLoadModule],
+      imports: [BulkLoadModule, DailyBackstopWorkspaceModule],
       providers: [
         ConfigService,
         DerivedHourlyValueMap,

--- a/src/emissions-workspace/emissions.service.ts
+++ b/src/emissions-workspace/emissions.service.ts
@@ -31,6 +31,7 @@ import { ReportingPeriod } from '../entities/workspace/reporting-period.entity';
 import { MonitorLocation } from '../entities/monitor-location.entity';
 import { EaseyException } from '@us-epa-camd/easey-common/exceptions/easey.exception';
 import { removeNonReportedValues } from '../utils/remove-non-reported-values';
+import { DailyBackstopWorkspaceService } from '../daily-backstop-workspace/daily-backstop.service';
 
 // Import Identifier: Table Id
 export type ImportIdentifiers = {
@@ -65,7 +66,8 @@ export class EmissionsWorkspaceService {
     private readonly nsps4tSummaryWorkspaceService: Nsps4tSummaryWorkspaceService,
     private readonly summaryValueWorkspaceService: SummaryValueWorkspaceService,
     private readonly longTermFuelFlowWorkspaceService: LongTermFuelFlowWorkspaceService,
-  ) {}
+    private readonly dailyBackstopWorkspaceService: DailyBackstopWorkspaceService
+  ) { }
 
   async delete(
     criteria: FindConditions<EmissionEvaluation>,
@@ -256,6 +258,14 @@ export class EmissionsWorkspaceService {
         identifiers,
         currentTime,
       ),
+      this.importDailyBackstop(
+        params,
+        monitoringLocations,
+        reportingPeriodId,
+        identifiers,
+        currentTime,
+      ),
+
     ];
 
     const importResults = await Promise.allSettled(importPromises);
@@ -413,6 +423,22 @@ export class EmissionsWorkspaceService {
     currentTime: string,
   ): Promise<void> {
     await this.longTermFuelFlowWorkspaceService.import(
+      emissionsImport,
+      monitoringLocations,
+      reportingPeriodId,
+      identifiers,
+      currentTime,
+    );
+  }
+
+  async importDailyBackstop(
+    emissionsImport: EmissionsImportDTO,
+    monitoringLocations: MonitorLocation[],
+    reportingPeriodId: number,
+    identifiers: ImportIdentifiers,
+    currentTime: string,
+  ): Promise<void> {
+    await this.dailyBackstopWorkspaceService.import(
       emissionsImport,
       monitoringLocations,
       reportingPeriodId,

--- a/src/entities/daily-backstop.entity.ts
+++ b/src/entities/daily-backstop.entity.ts
@@ -1,0 +1,117 @@
+import {
+    BaseEntity,
+    Column,
+    Entity,
+    JoinColumn,
+    ManyToOne,
+    PrimaryColumn,
+} from 'typeorm';
+import { NumericColumnTransformer } from '@us-epa-camd/easey-common/transforms';
+import { MonitorLocation } from './monitor-location.entity';
+import { ReportingPeriod } from './reporting-period.entity';
+
+@Entity({ name: 'camdecmps.daily_backstop' })
+export class DailyBackstop extends BaseEntity {
+    @PrimaryColumn({
+        name: 'daily_backstop_id',
+        nullable: false,
+    })
+    id: string;
+
+    @Column({
+        nullable: false,
+        type: 'date',
+        name: 'op_date',
+    })
+    date: Date;
+
+    @Column({
+        nullable: false,
+        name: 'daily_noxm',
+        transformer: new NumericColumnTransformer(),
+        precision: 10,
+        scale: 1,
+    })
+    dailyNoxEmissions: number;
+
+    @Column({
+        nullable: false,
+        name: 'daily_hit',
+        transformer: new NumericColumnTransformer(),
+        precision: 10,
+        scale: 1,
+    })
+    dailyHeatInput: number;
+
+    @Column({
+        nullable: true,
+        name: 'daily_avg_noxr',
+        transformer: new NumericColumnTransformer(),
+        precision: 7,
+        scale: 3,
+    })
+    dailyAverageNoxRate: number;
+
+    @Column({
+        nullable: false,
+        name: 'daily_noxm_exceed',
+        transformer: new NumericColumnTransformer(),
+        precision: 10,
+        scale: 1,
+    })
+    dailyNoxExceedence: number;
+
+    @Column({
+        nullable: true,
+        name: 'cumulative_os_noxm_exceed',
+        transformer: new NumericColumnTransformer(),
+        precision: 13,
+        scale: 1,
+    })
+    cumulativeOsNoxExceedence: number;
+
+    @Column({
+        nullable: false,
+        name: 'mon_loc_id',
+    })
+    monitoringLocationId: string;
+
+    @Column({
+        nullable: false,
+        name: 'rpt_period_id',
+        transformer: new NumericColumnTransformer(),
+    })
+    reportingPeriodId: number;
+
+    @Column({
+        name: 'userid',
+        nullable: true,
+    })
+    userId: string;
+
+    @Column({
+        name: 'add_date',
+        nullable: true,
+    })
+    addDate: Date;
+
+    @Column({
+        name: 'update_date',
+        nullable: true,
+    })
+    updateDate: Date;
+
+    @ManyToOne(
+        () => MonitorLocation,
+        o => o.dailyBackstops,
+    )
+    @JoinColumn({ name: 'mon_loc_id' })
+    monitorLocation: MonitorLocation;
+
+    @ManyToOne(
+        () => ReportingPeriod,
+        o => o.dailyBackstops,
+    )
+    @JoinColumn({ name: 'rpt_period_id' })
+    reportingPeriod: ReportingPeriod;
+}

--- a/src/entities/monitor-location.entity.ts
+++ b/src/entities/monitor-location.entity.ts
@@ -29,6 +29,7 @@ import { WeeklyTestSummary } from './weekly-test-summary.entity';
 import { Component } from './component.entity';
 import { HrlyParamFuelFlow } from './hrly-param-fuel-flow.entity';
 import { DerivedHrlyValue } from './derived-hrly-value.entity';
+import { DailyBackstop } from './daily-backstop.entity';
 
 @Entity({ name: 'camdecmps.monitor_location' })
 export class MonitorLocation extends BaseEntity {
@@ -208,4 +209,12 @@ export class MonitorLocation extends BaseEntity {
   )
   @JoinColumn({ name: 'mon_loc_id' })
   hrlyParamFuelFlows: HrlyParamFuelFlow[];
+
+  @OneToMany(
+    () => DailyBackstop,
+    o => o.monitorLocation,
+  )
+  @JoinColumn({ name: 'mon_loc_id' })
+  dailyBackstops: DailyBackstop[];
+
 }

--- a/src/entities/reporting-period.entity.ts
+++ b/src/entities/reporting-period.entity.ts
@@ -24,6 +24,7 @@ import { WeeklyTestSummary } from './weekly-test-summary.entity';
 import { SamplingTrain } from './sampling-train.entity';
 import { EmissionEvaluation } from './emission-evaluation.entity';
 import { DerivedHrlyValue } from './derived-hrly-value.entity';
+import { DailyBackstop } from './daily-backstop.entity';
 
 @Entity({ name: 'camdecmpsmd.reporting_period' })
 export class ReportingPeriod extends BaseEntity {
@@ -191,4 +192,12 @@ export class ReportingPeriod extends BaseEntity {
   )
   @JoinColumn({ name: 'rpt_period_id' })
   emissionEvaluations: EmissionEvaluation[];
+
+  @OneToMany(
+    () => EmissionEvaluation,
+    o => o.reportingPeriod,
+  )
+  @JoinColumn({ name: 'rpt_period_id' })
+  dailyBackstops: DailyBackstop[];
+
 }

--- a/src/entities/reporting-period.entity.ts
+++ b/src/entities/reporting-period.entity.ts
@@ -194,7 +194,7 @@ export class ReportingPeriod extends BaseEntity {
   emissionEvaluations: EmissionEvaluation[];
 
   @OneToMany(
-    () => EmissionEvaluation,
+    () => DailyBackstop,
     o => o.reportingPeriod,
   )
   @JoinColumn({ name: 'rpt_period_id' })

--- a/src/entities/workspace/daily-backstop.entity.ts
+++ b/src/entities/workspace/daily-backstop.entity.ts
@@ -10,7 +10,7 @@ import { NumericColumnTransformer } from '@us-epa-camd/easey-common/transforms';
 import { MonitorLocation } from './monitor-location.entity';
 import { ReportingPeriod } from './reporting-period.entity';
 
-@Entity({ name: 'camdecmps.daily_backstop' })
+@Entity({ name: 'camdecmpswks.daily_backstop' })
 export class DailyBackstop extends BaseEntity {
     @PrimaryColumn({
         name: 'daily_backstop_id',

--- a/src/entities/workspace/daily-backstop.entity.ts
+++ b/src/entities/workspace/daily-backstop.entity.ts
@@ -85,13 +85,13 @@ export class DailyBackstop extends BaseEntity {
 
     @Column({
         name: 'userid',
-        nullable: true,
+        nullable: false,
     })
     userId: string;
 
     @Column({
         name: 'add_date',
-        nullable: true,
+        nullable: false,
     })
     addDate: Date;
 

--- a/src/entities/workspace/daily-backstop.entity.ts
+++ b/src/entities/workspace/daily-backstop.entity.ts
@@ -1,0 +1,117 @@
+import {
+    BaseEntity,
+    Column,
+    Entity,
+    JoinColumn,
+    ManyToOne,
+    PrimaryColumn,
+} from 'typeorm';
+import { NumericColumnTransformer } from '@us-epa-camd/easey-common/transforms';
+import { MonitorLocation } from './monitor-location.entity';
+import { ReportingPeriod } from './reporting-period.entity';
+
+@Entity({ name: 'camdecmps.daily_backstop' })
+export class DailyBackstop extends BaseEntity {
+    @PrimaryColumn({
+        name: 'daily_backstop_id',
+        nullable: false,
+    })
+    id: string;
+
+    @Column({
+        nullable: false,
+        type: 'date',
+        name: 'op_date',
+    })
+    date: Date;
+
+    @Column({
+        nullable: false,
+        name: 'daily_noxm',
+        transformer: new NumericColumnTransformer(),
+        precision: 10,
+        scale: 1,
+    })
+    dailyNoxEmissions: number;
+
+    @Column({
+        nullable: false,
+        name: 'daily_hit',
+        transformer: new NumericColumnTransformer(),
+        precision: 10,
+        scale: 1,
+    })
+    dailyHeatInput: number;
+
+    @Column({
+        nullable: true,
+        name: 'daily_avg_noxr',
+        transformer: new NumericColumnTransformer(),
+        precision: 7,
+        scale: 3,
+    })
+    dailyAverageNoxRate: number;
+
+    @Column({
+        nullable: false,
+        name: 'daily_noxm_exceed',
+        transformer: new NumericColumnTransformer(),
+        precision: 10,
+        scale: 1,
+    })
+    dailyNoxExceedence: number;
+
+    @Column({
+        nullable: true,
+        name: 'cumulative_os_noxm_exceed',
+        transformer: new NumericColumnTransformer(),
+        precision: 13,
+        scale: 1,
+    })
+    cumulativeOsNoxExceedence: number;
+
+    @Column({
+        nullable: false,
+        name: 'mon_loc_id',
+    })
+    monitoringLocationId: string;
+
+    @Column({
+        nullable: false,
+        name: 'rpt_period_id',
+        transformer: new NumericColumnTransformer(),
+    })
+    reportingPeriodId: number;
+
+    @Column({
+        name: 'userid',
+        nullable: true,
+    })
+    userId: string;
+
+    @Column({
+        name: 'add_date',
+        nullable: true,
+    })
+    addDate: Date;
+
+    @Column({
+        name: 'update_date',
+        nullable: true,
+    })
+    updateDate: Date;
+
+    @ManyToOne(
+        () => MonitorLocation,
+        o => o.dailyBackstops,
+    )
+    @JoinColumn({ name: 'mon_loc_id' })
+    monitorLocation: MonitorLocation;
+
+    @ManyToOne(
+        () => ReportingPeriod,
+        o => o.dailyBackstops,
+    )
+    @JoinColumn({ name: 'rpt_period_id' })
+    reportingPeriod: ReportingPeriod;
+}

--- a/src/entities/workspace/monitor-location.entity.ts
+++ b/src/entities/workspace/monitor-location.entity.ts
@@ -30,6 +30,7 @@ import { Component } from './component.entity';
 import { MonitorSystem } from './monitor-system.entity';
 import { HrlyParamFuelFlow } from './hrly-param-fuel-flow.entity';
 import { MonitorFormula } from './monitor-formula.entity';
+import { DailyBackstop } from './daily-backstop.entity';
 
 @Entity({ name: 'camdecmpswks.monitor_location' })
 export class MonitorLocation extends BaseEntity {
@@ -216,4 +217,11 @@ export class MonitorLocation extends BaseEntity {
   )
   @JoinColumn({ name: 'mon_loc_id' })
   hrlyParamFuelFlows: HrlyParamFuelFlow[];
+
+  @OneToMany(
+    () => DailyBackstop,
+    o => o.monitorLocation,
+  )
+  @JoinColumn({ name: 'mon_loc_id' })
+  dailyBackstops: DailyBackstop[];
 }

--- a/src/entities/workspace/reporting-period.entity.ts
+++ b/src/entities/workspace/reporting-period.entity.ts
@@ -186,7 +186,7 @@ export class ReportingPeriod extends BaseEntity {
   emissionEvaluations: EmissionEvaluation[];
 
   @OneToMany(
-    () => EmissionEvaluation,
+    () => DailyBackstop,
     o => o.reportingPeriod,
   )
   @JoinColumn({ name: 'rpt_period_id' })

--- a/src/entities/workspace/reporting-period.entity.ts
+++ b/src/entities/workspace/reporting-period.entity.ts
@@ -23,6 +23,7 @@ import { SorbentTrap } from './sorbent-trap.entity';
 import { WeeklyTestSummary } from './weekly-test-summary.entity';
 import { SamplingTrain } from './sampling-train.entity';
 import { EmissionEvaluation } from './emission-evaluation.entity';
+import { DailyBackstop } from './daily-backstop.entity';
 
 @Entity({ name: 'camdecmpsmd.reporting_period' })
 export class ReportingPeriod extends BaseEntity {
@@ -183,4 +184,12 @@ export class ReportingPeriod extends BaseEntity {
   )
   @JoinColumn({ name: 'rpt_period_id' })
   emissionEvaluations: EmissionEvaluation[];
+
+  @OneToMany(
+    () => EmissionEvaluation,
+    o => o.reportingPeriod,
+  )
+  @JoinColumn({ name: 'rpt_period_id' })
+  dailyBackstops: DailyBackstop[];
+
 }

--- a/src/maps/daily-backstop.map.spec.ts
+++ b/src/maps/daily-backstop.map.spec.ts
@@ -1,0 +1,40 @@
+import { genDailyBackstop } from '../../test/object-generators/daily-backstop';
+import { DailyBackstop } from '../entities/daily-backstop.entity';
+import { DailyBackstop as DailyBackstopWorkspace } from '../entities/workspace/daily-backstop.entity';
+import { DailyBackstopMap } from './daily-backstop.map';
+
+describe('Daily Backstop Map Test', () => {
+  let map: DailyBackstopMap;
+  
+  beforeAll(() => {
+    map = new DailyBackstopMap();
+  });
+
+  it('should map values correctly', async function() {
+    const mocks = genDailyBackstop<DailyBackstop>(1);
+
+    const expectOne = async (mock: DailyBackstop | DailyBackstopWorkspace) => {
+      await expect(map.one(mock)).resolves.toEqual({
+        id: mock.id,
+        unitId: mock.monitorLocation?.unit?.name ?? null,
+        monitoringLocationId: mock.monitoringLocationId,
+        userId: mock.userId,
+        addDate: mock.addDate?.toISOString() ?? null,
+        updateDate: mock.updateDate?.toISOString() ?? null,
+        reportingPeriodId: mock.reportingPeriodId,
+        date: mock.date,
+        dailyNOxEmissions: mock.dailyNoxEmissions,
+        dailyHeatInput: mock.dailyHeatInput,
+        dailyAverageNOxRate: mock.dailyAverageNoxRate,
+        dailyNOxExceedence: mock.dailyNoxEmissions,
+        cumulativeOSNOxExceedence: mock.cumulativeOsNoxExceedence,
+  });
+    };
+
+    await Promise.all(
+      mocks.map(mock => {
+        return expectOne((mock as unknown) as DailyBackstop);
+      }),
+    );
+  });
+});

--- a/src/maps/daily-backstop.map.ts
+++ b/src/maps/daily-backstop.map.ts
@@ -1,0 +1,37 @@
+import { Injectable } from '@nestjs/common';
+import { BaseMap } from '@us-epa-camd/easey-common/maps';
+import { SummaryValue } from '../entities/summary-value.entity';
+import { SummaryValue as SummaryValueWorkspace } from '../entities/workspace/summary-value.entity';
+import { SummaryValueDTO } from '../dto/summary-value.dto';
+import { DailyBackstop } from '../entities/daily-backstop.entity';
+import { DailyBackstop as DailyBackstopWorkspace } from '../entities/workspace/daily-backstop.entity';
+import { DailyBackstopDTO } from '../dto/daily-backstop.dto';
+
+
+@Injectable()
+export class DailyBackstopMap extends BaseMap<
+    DailyBackstop | DailyBackstopWorkspace,
+    DailyBackstopDTO
+> {
+    public async one(
+        entity: DailyBackstop | DailyBackstopWorkspace,
+    ): Promise<DailyBackstopDTO> {
+        const unitId = entity?.monitorLocation?.unit?.name ?? null;
+
+        return {
+            id: entity.id,
+            unitId,
+            monitoringLocationId: entity.monitoringLocationId,
+            userId: entity.userId,
+            addDate: entity.addDate?.toISOString() ?? null,
+            updateDate: entity.updateDate?.toISOString() ?? null,
+            reportingPeriodId: entity.reportingPeriodId,
+            date: entity.date,
+            dailyNOxEmissions: entity.dailyNoxEmissions,
+            dailyHeatInput: entity.dailyHeatInput,
+            dailyAverageNOxRate: entity.dailyAverageNoxRate,
+            dailyNOxExceedence: entity.dailyNoxEmissions,
+            cumulativeOSNOxExceedence: entity.cumulativeOsNoxExceedence,
+        };
+    }
+}

--- a/src/maps/daily-backstop.map.ts
+++ b/src/maps/daily-backstop.map.ts
@@ -1,8 +1,5 @@
 import { Injectable } from '@nestjs/common';
 import { BaseMap } from '@us-epa-camd/easey-common/maps';
-import { SummaryValue } from '../entities/summary-value.entity';
-import { SummaryValue as SummaryValueWorkspace } from '../entities/workspace/summary-value.entity';
-import { SummaryValueDTO } from '../dto/summary-value.dto';
 import { DailyBackstop } from '../entities/daily-backstop.entity';
 import { DailyBackstop as DailyBackstopWorkspace } from '../entities/workspace/daily-backstop.entity';
 import { DailyBackstopDTO } from '../dto/daily-backstop.dto';

--- a/src/maps/emissions.map.ts
+++ b/src/maps/emissions.map.ts
@@ -34,6 +34,7 @@ export class EmissionsMap extends BaseMap<
       longTermFuelFlowData: [],
       sorbentTrapData: [],
       nsps4tSummaryData: [],
+      dailyBackstopData: [],
     };
   }
 }

--- a/src/monitor-location-workspace/monitor-location-checks.service.ts
+++ b/src/monitor-location-workspace/monitor-location-checks.service.ts
@@ -15,7 +15,7 @@ import { MonitorLocationWorkspaceRepository } from './monitor-location.repositor
 import { CheckCatalogService } from '@us-epa-camd/easey-common/check-catalog';
 import { isUndefinedOrNull } from '../utils/utils';
 import { Nsps4tSummaryImportDTO } from '../dto/nsps4t-summary.dto';
-import { DailyBackstopDTO } from '../dto/daily-backstop.dto';
+import { DailyBackstopImportDTO } from '../dto/daily-backstop.dto';
 
 // the following types have componentId field (and possibly other fields later on) which is needed for addLocation()
 type ForLocationType =
@@ -26,7 +26,7 @@ type ForLocationType =
   | LongTermFuelFlowImportDTO
   | SummaryValueImportDTO
   | Nsps4tSummaryImportDTO
-  | DailyBackstopDTO;
+  | DailyBackstopImportDTO;
 
 @Injectable()
 export class MonitorLocationChecksService {
@@ -128,7 +128,6 @@ export class MonitorLocationChecksService {
     payload?.dailyEmissionData?.forEach(i => addLocation(i));
     payload?.nsps4tSummaryData?.forEach(i => addLocation(i));
     payload?.dailyBackstopData?.forEach(i => addLocation(i));
-
 
     return locations;
   }

--- a/src/monitor-location-workspace/monitor-location-checks.service.ts
+++ b/src/monitor-location-workspace/monitor-location-checks.service.ts
@@ -15,6 +15,7 @@ import { MonitorLocationWorkspaceRepository } from './monitor-location.repositor
 import { CheckCatalogService } from '@us-epa-camd/easey-common/check-catalog';
 import { isUndefinedOrNull } from '../utils/utils';
 import { Nsps4tSummaryImportDTO } from '../dto/nsps4t-summary.dto';
+import { DailyBackstopDTO } from '../dto/daily-backstop.dto';
 
 // the following types have componentId field (and possibly other fields later on) which is needed for addLocation()
 type ForLocationType =
@@ -24,7 +25,8 @@ type ForLocationType =
   | SorbentTrapImportDTO
   | LongTermFuelFlowImportDTO
   | SummaryValueImportDTO
-  | Nsps4tSummaryImportDTO;
+  | Nsps4tSummaryImportDTO
+  | DailyBackstopDTO;
 
 @Injectable()
 export class MonitorLocationChecksService {
@@ -37,11 +39,11 @@ export class MonitorLocationChecksService {
     const locations: LocationIdentifiers[] = [];
 
     const addLocation = (i: ForLocationType) => {
-      const unitId = i?.unitId;
-      const stackPipeId = i?.stackPipeId;
+      const unitId = i["unitId"];
+      const stackPipeId = i["stackPipeId"];
       let location = locations.find(l => {
-        const locationUnitId = l?.unitId;
-        const locationStackPipeId = l?.stackPipeId;
+        const locationUnitId = l["unitId"];
+        const locationStackPipeId = l["stackPipeId"];
         if (unitId) return locationUnitId === unitId;
         if (stackPipeId) return locationStackPipeId === stackPipeId;
       });
@@ -50,7 +52,7 @@ export class MonitorLocationChecksService {
         location = {
           unitId: i.unitId,
           locationId: null,
-          stackPipeId: i.stackPipeId,
+          stackPipeId: i["stackPipeId"],
           componentIds: new Set<string>(),
           monitoringSystemIds: new Set<string>(),
           ltffMonitoringSystemIds: new Set<string>(),
@@ -125,6 +127,8 @@ export class MonitorLocationChecksService {
     payload?.summaryValueData?.forEach(i => addLocation(i));
     payload?.dailyEmissionData?.forEach(i => addLocation(i));
     payload?.nsps4tSummaryData?.forEach(i => addLocation(i));
+    payload?.dailyBackstopData?.forEach(i => addLocation(i));
+
 
     return locations;
   }

--- a/test/object-generators/daily-backstop-dto.ts
+++ b/test/object-generators/daily-backstop-dto.ts
@@ -1,0 +1,20 @@
+import { faker } from "@faker-js/faker";
+import { DailyBackstopImportDTO } from "../../src/dto/daily-backstop.dto";
+
+export const genDailyBackstopImportDto = (amount = 1) => {
+    const dailyBackstopData: DailyBackstopImportDTO[] = [];
+
+    for (let i = 0; i < amount; i++) {
+        dailyBackstopData.push({
+            unitId: faker.datatype.string(),            
+            date: faker.datatype.datetime(),
+            dailyNOxEmissions: faker.datatype.number(),
+            dailyHeatInput: faker.datatype.number(),
+            dailyAverageNOxRate: faker.datatype.number(),
+            dailyNOxExceedence: faker.datatype.number(),
+            cumulativeOSNOxExceedence: faker.datatype.number(),
+        });
+    }
+
+    return dailyBackstopData;
+};

--- a/test/object-generators/daily-backstop.ts
+++ b/test/object-generators/daily-backstop.ts
@@ -1,0 +1,39 @@
+import { faker } from '@faker-js/faker';
+import { genMonitorLocation } from './monitor-location';
+import { genReportingPeriod } from './reporting-period';
+
+type GenDailyBackstopConfig = {
+    include?: Array<'monitorLocation' | 'reportingPeriod'>;
+};
+
+export const genDailyBackstop = <RepoType>(
+    amount = 1,
+    config?: GenDailyBackstopConfig,
+) => {
+    const dailyBackstopData: RepoType[] = [];
+
+    for (let i = 0; i < amount; i++) {
+        dailyBackstopData.push(({
+            id: faker.datatype.string(),
+            reportingPeriodId: faker.datatype.string(),
+            monitoringLocationId: faker.datatype.string(),
+            date: faker.datatype.datetime(),
+            dailyNoxEmissions: faker.datatype.number(),
+            dailyHeatInput: faker.datatype.number(),
+            dailyAverageNoxRate: faker.datatype.number(),
+            dailyNoxExceedence: faker.datatype.number(),
+            cumulativeOsNoxExceedence: faker.datatype.number(),
+            userId: faker.datatype.string(),
+            addDate: faker.datatype.datetime(),
+            updateDate: faker.datatype.datetime(),
+            monitorLocation: config?.include?.includes('monitorLocation')
+                ? genMonitorLocation()[0]
+                : undefined,
+            reportingPeriod: config?.include?.includes('reportingPeriod')
+                ? genReportingPeriod()[0]
+                : undefined,
+        } as unknown) as RepoType);
+    }
+
+    return dailyBackstopData;
+};

--- a/test/object-generators/emissions-dto.ts
+++ b/test/object-generators/emissions-dto.ts
@@ -37,6 +37,7 @@ import {
   HourlyOperatingImportDtoConfig,
 } from './hourly-operating-dto';
 import { genHourlyOpValues } from './hourly-op-data-values';
+import { DailyBackstopDTO, DailyBackstopImportDTO } from '../../src/dto/daily-backstop.dto';
 
 type GenEmissionsDtoConfig = {
   include?: Array<
@@ -48,6 +49,7 @@ type GenEmissionsDtoConfig = {
     | 'longTermFuelFlowData'
     | 'sorbentTrapData'
     | 'nsps4tSummaryData'
+    | 'dailyBackstopData'
   >;
   dailyTestSummaryAmount?: number;
   hourlyOperatingAmount?: number;
@@ -107,9 +109,9 @@ export const genEmissionsImportDto = (
         : undefined,
       hourlyOperatingData: config?.include?.includes('hourlyOperatingData')
         ? genHourlyOperatingImportDto(
-            config?.hourlyOperatingAmount,
-            config?.hourlyOperatingImportConfig,
-          )
+          config?.hourlyOperatingAmount,
+          config?.hourlyOperatingImportConfig,
+        )
         : undefined,
       longTermFuelFlowData: config?.include?.includes('longTermFuelFlowData')
         ? [new LongTermFuelFlowImportDTO()]
@@ -120,6 +122,9 @@ export const genEmissionsImportDto = (
       nsps4tSummaryData: config?.include?.includes('nsps4tSummaryData')
         ? [new Nsps4tSummaryImportDTO()]
         : undefined,
+      dailyBackstopData: config?.include?.includes('dailyBackstopData')
+        ? [new DailyBackstopImportDTO()]
+        : undefined
     });
   }
 
@@ -166,6 +171,9 @@ export const genEmissionsRecordDto = (
         : undefined,
       nsps4tSummaryData: config?.include?.includes('nsps4tSummaryData')
         ? [new Nsps4tSummaryDTO()]
+        : undefined,
+      dailyBackstopData: config?.include?.includes('dailyBackstopData')
+        ? [new DailyBackstopDTO()]
         : undefined,
     });
   }


### PR DESCRIPTION
## Pull Request

Added import for daily-backstop data.

The following JSON can be used and/or modified to test the import:
```
{
	"orisCode": 1915,
	"monitorPlanId": "MDC-048B9BC304774A0BADA8E13D111424FF",
	"reportingPeriodId": 117,
	"year": 2022,
	"quarter": 1,
	"submissionComment": null,
	"lastUpdated": "2022-04-12T08:34:40.000Z",
	"updatedStatusFlg": null,
	"needsEvalFlag": null,
	"chkSessionId": null,
	"submissionId": 1495782,
	"submissionAvailabilityCd": "UPDATED",
	"dailyBackstopData": [
		{
			"reportingPeriodId": 117,
			"monitoringLocationId": "988",
			"unitId": "1",
			"date": "2022-01-04T00:00:00.000Z",
			"dailyNOxEmissions":12,
			"dailyHeatInput":122,
			"dailyAverageNOxRate":0.123,
			"dailyNOxExceedence":111,
			"cumulativeOSNOxExceedence":12
		}
	]
}
```
