### PR TITLE
🐛 Bug/5662: Evaluation and Submission Statuses

### DIFF
--- a/src/emissions-workspace/emissions.service.ts
+++ b/src/emissions-workspace/emissions.service.ts
@@ -291,6 +291,7 @@ export class EmissionsWorkspaceService {
           evalStatusCd: 'EVAL',
           needsEvalFlag: 'Y',
           updatedStatusFlg: 'Y',
+          submissionAvailabilityCd: 'REQUIRE',
           lastUpdated: new Date(),
         }),
       );

--- a/src/emissions-workspace/emissions.service.ts
+++ b/src/emissions-workspace/emissions.service.ts
@@ -289,6 +289,8 @@ export class EmissionsWorkspaceService {
           monitorPlanId,
           reportingPeriodId,
           evalStatusCd: 'EVAL',
+          needsEvalFlag: 'Y',
+          updatedStatusFlg: 'Y',
           lastUpdated: new Date(),
         }),
       );


### PR DESCRIPTION
## [🐛 Bug/5662: Evaluation and Submission Statuses](https://app.zenhub.com/workspaces/ecmps-prod-team-64623d2269329d0c96ba04f3/issues/gh/us-epa-camd/easey-ui/5662)

### Description:

- set `needsEvalFlag` and `updatedStatusFlag` to 'Y' on emission import
-  set `submissionAvailiblityCode` to `REQUIRE`.

