### PR TITLE
fix/update validation for ozone season

### DIFF
--- a/src/dto/ozone-apportioned-emissions.params.dto.ts
+++ b/src/dto/ozone-apportioned-emissions.params.dto.ts
@@ -9,7 +9,7 @@ import {
 } from '@us-epa-camd/easey-common/constants';
 import { ExcludeApportionedEmissions } from '@us-epa-camd/easey-common/enums';
 
-import { OpYear, Page, PerPage } from '../utils/validator.const';
+import { OzoneDate, Page, PerPage } from '../utils/validator.const';
 import { ApportionedEmissionsParamsDTO } from './apportioned-emissions.params.dto';
 import { fieldMappings } from '../constants/field-mappings';
 
@@ -18,7 +18,7 @@ export class OzoneApportionedEmissionsParamsDTO extends ApportionedEmissionsPara
     isArray: true,
     description: propertyMetadata.year.description,
   })
-  @OpYear()
+  @OzoneDate()
   @Transform(({ value }) => value.split('|').map((item: string) => item.trim()))
   year: number[];
 }

--- a/src/utils/validator.const.ts
+++ b/src/utils/validator.const.ts
@@ -1,5 +1,5 @@
 import { applyDecorators } from '@nestjs/common';
-import { IsNotEmpty } from 'class-validator';
+import {ArrayNotContains, IsNotEmpty, ValidateIf } from 'class-validator';
 import { ErrorMessages } from '@us-epa-camd/easey-common/constants';
 import {
   IsInDateRange,
@@ -107,5 +107,37 @@ export function OpYear() {
       message: ErrorMessages.MultipleFormat('year', 'YYYY format'),
     }),
     IsNotEmptyString({ message: ErrorMessages.RequiredProperty() }),
+  );
+}
+
+export function OzoneDate() {
+  return applyDecorators(
+    IsInDateRange(new Date(1995, 0), true, false, false, {
+      each: true,
+      message: ErrorMessages.DateRange(
+        'year',
+        true,
+        `a year between 1995 and the quarter ending on 09/30/${new Date().getFullYear()}`,
+      ),
+    }),
+    IsYearFormat({
+      each: true,
+      message: ErrorMessages.MultipleFormat('year', 'YYYY format'),
+    }),
+    IsNotEmptyString({ message: ErrorMessages.RequiredProperty() }),
+    ValidateIf(o => {
+      const year = new Date().getFullYear();
+      if (o.year.includes(year.toString()) && new Date() <= new Date(`October 01 ${year}`)) {
+        return true
+      }
+      return false
+    }),
+    ArrayNotContains([new Date().getFullYear().toString()], {
+      message: ErrorMessages.DateRange(
+        'year',
+        true,
+        `a year between 1995 and the quarter ending on 09/30/${new Date().getFullYear()}`,
+      ),
+    })
   );
 }


### PR DESCRIPTION
## Ticket
[Update Validation for Ozone Season](https://app.zenhub.com/workspaces/dpcerg-scrum-board-5f36cc8dfed6db0022b0f4db/issues/gh/us-epa-camd/easey-ui/2536)

## Changes

1. Added new validation for OzoneDate this will affect for `Apportioned Ozone Emissions` APIs 
validation:- If year array includes current year, then check current date is less than October 1st. if yes, then validate with ArrayNotContain’s current year.
