### PR TITLE
Fix/2536 ozone season

### DIFF
--- a/package.json
+++ b/package.json
@@ -54,6 +54,7 @@
     "uuid": "^8.3.2"
   },
   "devDependencies": {
+    "@faker-js/faker": "^7.5.0",
     "@nestjs/cli": "^8.1.4",
     "@nestjs/schematics": "^8.0.4",
     "@nestjs/testing": "^8.1.1",

--- a/src/apportioned-emissions/apportioned-emissions.controller.spec.ts
+++ b/src/apportioned-emissions/apportioned-emissions.controller.spec.ts
@@ -4,7 +4,7 @@ import { LoggerModule } from '@us-epa-camd/easey-common/logger';
 
 import { ApportionedEmissionsController } from './apportioned-emissions.controller';
 import { ApportionedEmissionsService } from './apportioned-emissions.service';
-import { ProgramYearDimRepository } from './unit-fact.repository';
+import { UnitFactRepository } from './unit-fact.repository';
 import { ApplicableApportionedEmissionsAttributesDTO } from '../dto/applicable-apportioned-emissions-attributes.dto';
 
 const mockRequest = (url: string) => {
@@ -25,7 +25,7 @@ describe('-- Apportioned Emissions Controller --', () => {
     const module = await Test.createTestingModule({
       imports: [LoggerModule],
       controllers: [ApportionedEmissionsController],
-      providers: [ApportionedEmissionsService, ProgramYearDimRepository],
+      providers: [ApportionedEmissionsService, UnitFactRepository],
     }).compile();
 
     controller = module.get(ApportionedEmissionsController);

--- a/src/apportioned-emissions/mats/mats-apportioned-emissions.controller.spec.ts
+++ b/src/apportioned-emissions/mats/mats-apportioned-emissions.controller.spec.ts
@@ -3,11 +3,12 @@ import { Test } from '@nestjs/testing';
 import { LoggerModule } from '@us-epa-camd/easey-common/logger';
 
 import { MatsApportionedEmissionsService } from './mats-apportioned-emissions.service';
-import { ApplicableMatsApportionedEmissionsAttributesParamsDTO } from '../../dto/applicable-mats-apportioned-emissions-attributes-params.dto';
-import { ApplicableMatsApportionedEmissionsAttributesDTO } from '../../dto/applicable-mats-apportioned-emissions-attributes.dto';
 import { HourUnitMatsDataRepository } from './hourly/hour-unit-mats-data.repository';
 import { MatsApportionedEmissionsController } from './mats-apportioned-emissions.controller';
 import { HourlyMatsApportionedEmissionsService } from './hourly/hourly-mats-apportioned-emissions.service';
+import { ApplicableApportionedEmissionsAttributesParamsDTO } from '../../dto/applicable-apportioned-emissions-attributes.params.dto';
+import { UnitFactRepository } from '../unit-fact.repository';
+import { genApplicableApportionedEmissionsAttributesDto } from '../../../test/object-generators/apportioned-emissions';
 
 const mockRequest = (url: string) => {
   return {
@@ -31,6 +32,7 @@ describe('-- MATS Apportioned Emissions Controller --', () => {
         MatsApportionedEmissionsService,
         HourlyMatsApportionedEmissionsService,
         HourUnitMatsDataRepository,
+        UnitFactRepository,
       ],
     }).compile();
 
@@ -45,11 +47,11 @@ describe('-- MATS Apportioned Emissions Controller --', () => {
   });
 
   describe('* getApplicableEmissions', () => {
-    it('should return test 1', async () => {
-      const expectedResult: ApplicableMatsApportionedEmissionsAttributesDTO[] = [];
-      const paramsDto = new ApplicableMatsApportionedEmissionsAttributesParamsDTO();
+    it('calls MatsApportionedEmissionsService.getApplicableApportionedEmissionsAttributes() and gets all emissions data', async () => {
+      const expectedResult = genApplicableApportionedEmissionsAttributesDto();
+      const paramsDto = new ApplicableApportionedEmissionsAttributesParamsDTO();
       jest
-        .spyOn(service, 'getApplicableEmissions')
+        .spyOn(service, 'getApplicableApportionedEmissionsAttributes')
         .mockResolvedValue(expectedResult);
       expect(await controller.getApplicableEmissions(paramsDto)).toBe(
         expectedResult,

--- a/src/dto/ozone-apportioned-emissions.params.dto.ts
+++ b/src/dto/ozone-apportioned-emissions.params.dto.ts
@@ -9,7 +9,7 @@ import {
 } from '@us-epa-camd/easey-common/constants';
 import { ExcludeApportionedEmissions } from '@us-epa-camd/easey-common/enums';
 
-import { OpYear, Page, PerPage } from '../utils/validator.const';
+import { OzoneDate, Page, PerPage } from '../utils/validator.const';
 import { ApportionedEmissionsParamsDTO } from './apportioned-emissions.params.dto';
 import { fieldMappings } from '../constants/field-mappings';
 
@@ -18,7 +18,7 @@ export class OzoneApportionedEmissionsParamsDTO extends ApportionedEmissionsPara
     isArray: true,
     description: propertyMetadata.year.description,
   })
-  @OpYear()
+  @OzoneDate()
   @Transform(({ value }) => value.split('|').map((item: string) => item.trim()))
   year: number[];
 }

--- a/src/emissions/emissions.controller.spec.ts
+++ b/src/emissions/emissions.controller.spec.ts
@@ -1,48 +1,48 @@
-// import { ConfigService } from '@nestjs/config';
-// import { Test, TestingModule } from '@nestjs/testing';
-// import { LoggerModule } from '@us-epa-camd/easey-common/logger';
-// import { EmissionSubmissionsProgressMap } from '../maps/emissions-submissions-progress.map';
-// import { EmissionController } from './emissions.controller';
-// import { EmissionsRepository } from './emissions.repository';
-// import { EmissionService } from './emissions.service';
+import { ConfigService } from '@nestjs/config';
+import { Test, TestingModule } from '@nestjs/testing';
+import { LoggerModule } from '@us-epa-camd/easey-common/logger';
+import { EmissionsSubmissionsProgressMap } from '../maps/emissions-submissions-progress.map';
+import { EmissionsController } from './emissions.controller';
+import { EmissionsSubmissionsProgressRepository } from './emissions-submissions-progress.repository';
+import { EmissionsService } from './emissions.service';
 
-// const mockEmissionsRepository = () => ({
-//   getSubmissionProgress: jest.fn(),
-// });
+const mockEmissionsRepository = () => ({
+  getSubmissionProgress: jest.fn(),
+});
 
-// describe('Emissions Controller', () => {
-//   let controller: EmissionController;
-//   let service: EmissionService;
+describe('Emissions Controller', () => {
+  let controller: EmissionsController;
+  let service: EmissionsService;
 
-//   beforeAll(async () => {
-//     const module: TestingModule = await Test.createTestingModule({
-//       imports: [LoggerModule],
-//       controllers: [EmissionController],
-//       providers: [
-//         EmissionService,
-//         EmissionSubmissionsProgressMap,
-//         ConfigService,
-//         { provide: EmissionsRepository, useFactory: mockEmissionsRepository },
-//       ],
-//     }).compile();
+  beforeAll(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      imports: [LoggerModule],
+      controllers: [EmissionsController],
+      providers: [
+        EmissionsService,
+        EmissionsSubmissionsProgressMap,
+        ConfigService,
+        { provide: EmissionsSubmissionsProgressRepository, useFactory: mockEmissionsRepository },
+      ],
+    }).compile();
 
-//     controller = module.get(EmissionController);
-//     service = module.get(EmissionService);
-//   });
+    controller = module.get(EmissionsController);
+    service = module.get(EmissionsService);
+  });
 
-//   it('should be defined', () => {
-//     expect(controller).toBeDefined();
-//   });
+  it('should be defined', () => {
+    expect(controller).toBeDefined();
+  });
 
-//   describe('Get Methods', () => {
-//     it('should return the provided data', async () => {
-//       const data = undefined;
+  describe('Get Methods', () => {
+    it('should return the provided data', async () => {
+      const data = undefined;
 
-//       jest.spyOn(service, 'getSubmissionProgress').mockResolvedValue(data);
+      jest.spyOn(service, 'getSubmissionProgress').mockResolvedValue(data);
 
-//       expect(
-//         await controller.submissionProgress({ submissionPeriod: new Date() }),
-//       ).toBe(data);
-//     });
-//   });
-// });
+      expect(
+        await controller.submissionProgress({ submissionPeriod: new Date() }),
+      ).toBe(data);
+    });
+  });
+});

--- a/src/utils/validator.const.ts
+++ b/src/utils/validator.const.ts
@@ -1,5 +1,5 @@
 import { applyDecorators } from '@nestjs/common';
-import { IsNotEmpty } from 'class-validator';
+import {ArrayNotContains, IsNotEmpty, ValidateIf } from 'class-validator';
 import { ErrorMessages } from '@us-epa-camd/easey-common/constants';
 import {
   IsInDateRange,
@@ -107,5 +107,37 @@ export function OpYear() {
       message: ErrorMessages.MultipleFormat('year', 'YYYY format'),
     }),
     IsNotEmptyString({ message: ErrorMessages.RequiredProperty() }),
+  );
+}
+
+export function OzoneDate() {
+  return applyDecorators(
+    IsInDateRange(new Date(1995, 0), true, false, false, {
+      each: true,
+      message: ErrorMessages.DateRange(
+        'year',
+        true,
+        `a year between 1995 and the quarter ending on 09/30/${new Date().getFullYear()}`,
+      ),
+    }),
+    IsYearFormat({
+      each: true,
+      message: ErrorMessages.MultipleFormat('year', 'YYYY format'),
+    }),
+    IsNotEmptyString({ message: ErrorMessages.RequiredProperty() }),
+    ValidateIf(o => {
+      const year = new Date().getFullYear();
+      if (o.year.includes(year.toString()) && new Date() <= new Date(`October 01 ${year}`)) {
+        return true
+      }
+      return false
+    }),
+    ArrayNotContains([new Date().getFullYear().toString()], {
+      message: ErrorMessages.DateRange(
+        'year',
+        true,
+        `a year between 1995 and the quarter ending on 09/30/${new Date().getFullYear()}`,
+      ),
+    })
   );
 }

--- a/test/object-generators/apportioned-emissions.ts
+++ b/test/object-generators/apportioned-emissions.ts
@@ -1,0 +1,20 @@
+import { faker } from '@faker-js/faker';
+import { ApplicableApportionedEmissionsAttributesDTO } from 'src/dto/applicable-apportioned-emissions-attributes.dto';
+
+export const genApplicableApportionedEmissionsAttributesDto = (amount = 1) => {
+    const dtos: ApplicableApportionedEmissionsAttributesDTO[] = [];
+  
+    for (let dto = 0; dto < amount; dto++) {
+      dtos.push({
+        year: faker.datatype.number(),
+        programCode: faker.datatype.string(),
+        facilityId: faker.datatype.number(),
+        stateCode: faker.datatype.string(),
+        unitTypeCode: faker.datatype.string(),
+        fuelTypeCode: faker.datatype.string(),
+        controlCode: faker.datatype.string(),
+      });
+    }
+  
+    return dtos;
+  };

--- a/yarn.lock
+++ b/yarn.lock
@@ -377,6 +377,11 @@
     minimatch "^3.1.2"
     strip-json-comments "^3.1.1"
 
+"@faker-js/faker@^7.5.0":
+  version "7.6.0"
+  resolved "https://registry.yarnpkg.com/@faker-js/faker/-/faker-7.6.0.tgz#9ea331766084288634a9247fcd8b84f16ff4ba07"
+  integrity sha512-XK6BTq1NDMo9Xqw/YkYyGjSsg44fbNwYRx7QK2CuoQgyy+f1rrTDHoExVM5PsyXCtfl2vs2vVJ0MN0yN6LppRw==
+
 "@humanwhocodes/config-array@^0.10.5":
   version "0.10.7"
   resolved "https://registry.yarnpkg.com/@humanwhocodes/config-array/-/config-array-0.10.7.tgz#6d53769fd0c222767e6452e8ebda825c22e9f0dc"


### PR DESCRIPTION
## Ticket
[Update Validation for Ozone Season](https://app.zenhub.com/workspaces/dpcerg-scrum-board-5f36cc8dfed6db0022b0f4db/issues/gh/us-epa-camd/easey-ui/2536)

## Changes

1. Added new validation for OzoneDate this will affect for `Apportioned Ozone Emissions` APIs 
validation:- If year array includes current year, then check current date is less than October 1st. if yes, then validate with ArrayNotContain’s current year.
2. **Update failed unit test**
3. **Added `"@faker-js/faker": "^7.5.0"` package**

related: https://github.com/US-EPA-CAMD/easey-emissions-api/pull/426, https://github.com/US-EPA-CAMD/easey-emissions-api/pull/423
