### PR TITLE
fix:emission schema NOx to Nox and OS to Os

### DIFF
--- a/src/daily-backstop-workspace/daily-backstop.service.ts
+++ b/src/daily-backstop-workspace/daily-backstop.service.ts
@@ -62,21 +62,21 @@ export class DailyBackstopWorkspaceService {
         
           const {
             date,
-            dailyNOxEmissions,
+            dailyNoxEmissions,
             dailyHeatInput,
-            dailyAverageNOxRate,
-            dailyNOxExceedence,
-            cumulativeOSNOxExceedence,
+            dailyAverageNoxRate,
+            dailyNoxExceedence,
+            cumulativeOsNoxExceedence,
           } = dailyBackstopDatum;
     
           bulkLoadStream.writeObject({
             unitId: monitoringLocation?.unit?.id ?? null,
             date,
-            dailyNOxEmissions,
+            dailyNoxEmissions,
             dailyHeatInput,
-            dailyAverageNOxRate,
-            dailyNOxExceedence,
-            cumulativeOSNOxExceedence,
+            dailyAverageNoxRate,
+            dailyNoxExceedence,
+            cumulativeOsNoxExceedence,
             monitoringLocationId: monitoringLocation?.id ?? null,
             reportingPeriodId,
             userId: identifiers?.userId,

--- a/src/dto/daily-backstop.dto.ts
+++ b/src/dto/daily-backstop.dto.ts
@@ -13,19 +13,19 @@ export class DailyBackstopBaseDTO {
     date: Date;
   
     @IsNumber()
-    dailyNOxEmissions?: number;
+    dailyNoxEmissions?: number;
   
     @IsNumber()
     dailyHeatInput?: number;
     
     @IsNumber()
-    dailyAverageNOxRate?: number;
+    dailyAverageNoxRate?: number;
   
     @IsNumber()
-    dailyNOxExceedence?: number;
+    dailyNoxExceedence?: number;
 
     @IsNumber()
-    cumulativeOSNOxExceedence?: number;
+    cumulativeOsNoxExceedence?: number;
   }
 
 export class DailyBackstopRecordDTO extends DailyBackstopBaseDTO{

--- a/src/maps/daily-backstop.map.spec.ts
+++ b/src/maps/daily-backstop.map.spec.ts
@@ -23,11 +23,11 @@ describe('Daily Backstop Map Test', () => {
         updateDate: mock.updateDate?.toISOString() ?? null,
         reportingPeriodId: mock.reportingPeriodId,
         date: mock.date,
-        dailyNOxEmissions: mock.dailyNoxEmissions,
+        dailyNoxEmissions: mock.dailyNoxEmissions,
         dailyHeatInput: mock.dailyHeatInput,
-        dailyAverageNOxRate: mock.dailyAverageNoxRate,
-        dailyNOxExceedence: mock.dailyNoxExceedence,
-        cumulativeOSNOxExceedence: mock.cumulativeOsNoxExceedence,
+        dailyAverageNoxRate: mock.dailyAverageNoxRate,
+        dailyNoxExceedence: mock.dailyNoxExceedence,
+        cumulativeOsNoxExceedence: mock.cumulativeOsNoxExceedence,
   });
     };
 

--- a/src/maps/daily-backstop.map.ts
+++ b/src/maps/daily-backstop.map.ts
@@ -24,11 +24,11 @@ export class DailyBackstopMap extends BaseMap<
             updateDate: entity.updateDate?.toISOString() ?? null,
             reportingPeriodId: entity.reportingPeriodId,
             date: entity.date,
-            dailyNOxEmissions: entity.dailyNoxEmissions,
+            dailyNoxEmissions: entity.dailyNoxEmissions,
             dailyHeatInput: entity.dailyHeatInput,
-            dailyAverageNOxRate: entity.dailyAverageNoxRate,
-            dailyNOxExceedence: entity.dailyNoxExceedence,
-            cumulativeOSNOxExceedence: entity.cumulativeOsNoxExceedence,
+            dailyAverageNoxRate: entity.dailyAverageNoxRate,
+            dailyNoxExceedence: entity.dailyNoxExceedence,
+            cumulativeOsNoxExceedence: entity.cumulativeOsNoxExceedence,
         };
     }
 }

--- a/test/object-generators/daily-backstop-dto.ts
+++ b/test/object-generators/daily-backstop-dto.ts
@@ -8,11 +8,11 @@ export const genDailyBackstopImportDto = (amount = 1) => {
         dailyBackstopData.push({
             unitId: faker.datatype.string(),            
             date: faker.datatype.datetime(),
-            dailyNOxEmissions: faker.datatype.number(),
+            dailyNoxEmissions: faker.datatype.number(),
             dailyHeatInput: faker.datatype.number(),
-            dailyAverageNOxRate: faker.datatype.number(),
-            dailyNOxExceedence: faker.datatype.number(),
-            cumulativeOSNOxExceedence: faker.datatype.number(),
+            dailyAverageNoxRate: faker.datatype.number(),
+            dailyNoxExceedence: faker.datatype.number(),
+            cumulativeOsNoxExceedence: faker.datatype.number(),
         });
     }
 


### PR DESCRIPTION
## Ticket
[Schema capitalization correction](https://github.com/US-EPA-CAMD/easey-ui/issues/6028)

## Changes

1. dailyNOxEmissions -> dailyNoxEmissions
2. dailyAverageNOxRate -> dailyAverageNoxRate
3. dailyNOxExceedence -> dailyNoxExceedence
4. cumulativeOSNOxExceedence -> cumulativeOsNoxExceedence