### PR TITLE
Fix/6102 forbidden resource errors

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
     "@nestjs/platform-express": "^8.4.7",
     "@nestjs/swagger": "^7.0.4",
     "@nestjs/typeorm": "8.0.3",
-    "@us-epa-camd/easey-common": "^17.2.11",
+    "@us-epa-camd/easey-common": "^17.2.12",
     "class-transformer": "0.4.0",
     "class-validator": "0.14.0",
     "dotenv": "^10.0.0",

--- a/src/config/app.config.ts
+++ b/src/config/app.config.ts
@@ -67,8 +67,17 @@ export default registerAs('app', () => ({
   reqSizeLimit: getConfigValue('EASEY_EMISSIONS_API_REQ_SIZE_LIMIT', '60mb'),
   // ENABLES DEBUG CONSOLE LOGS
   enableDebug: getConfigValueBoolean('EASEY_EMISSIONS_API_ENABLE_DEBUG'),
-  // NEEDS TO BE SET IN .ENV FILE FOR LOCAL DEVELOPMENT
-  // FORMAT: { "userId": "", "roles": [ { "orisCode": 3, "role": "P" } ] }
+  /**
+   * Needs to be set in .env file for local development if `EASEY_EMISSIONS_API_ENABLE_AUTH_TOKEN` is false.
+   * Format:
+   *   {
+   *       "facilities": [
+   *           { "facId": number, "orisCode": number, "permissions": string[] }
+   *       ],
+   *       "roles": <"Preparer" | "Submitter" | "Sponsor">[],
+   *       "userId": string
+   *   }
+   */
   currentUser: getConfigValue(
     'EASEY_EMISSIONS_API_CURRENT_USER',
     '{"userId": ""}',

--- a/src/emissions-workspace/emissions.controller.ts
+++ b/src/emissions-workspace/emissions.controller.ts
@@ -109,7 +109,7 @@ export class EmissionsWorkspaceController {
         'sorbentTrapData',
         'nsps4tSummaryData',
       ],
-      permissionsForFacility: ['DSEM', 'DPEM'],
+      permissionsForFacility: ['DSEM'],
       requiredRoles: ['Preparer', 'Submitter', 'Sponsor'],
     },
     LookupType.Location,

--- a/yarn.lock
+++ b/yarn.lock
@@ -1229,10 +1229,10 @@
   resolved "https://registry.yarnpkg.com/@ungap/structured-clone/-/structured-clone-1.2.0.tgz#756641adb587851b5ccb3e095daf27ae581c8406"
   integrity sha512-zuVdFrMJiuCDQUMCzQaD6KL28MjnqqN8XnAqiEq9PNm/hCPTSGfrXCOfwj1ow4LFb/tNymJPwsNbVePc1xFqrQ==
 
-"@us-epa-camd/easey-common@^17.2.11":
-  version "17.2.11"
-  resolved "https://npm.pkg.github.com/download/@US-EPA-CAMD/easey-common/17.2.11/a83d61ed3141473d769973ca8d4f79b257f279a5#a83d61ed3141473d769973ca8d4f79b257f279a5"
-  integrity sha512-bApTlGpG1mNlBM5qtoPDdMP/Di0DyNx30RoIQYdJXNbJ39y6dKBGSqk4q83pZMthTCVu6Z5ptt226Kcf8RlQXA==
+"@us-epa-camd/easey-common@^17.2.12":
+  version "17.2.12"
+  resolved "https://npm.pkg.github.com/download/@US-EPA-CAMD/easey-common/17.2.12/68bb9cc590a6375b56c3a2457c27d42479e978f4#68bb9cc590a6375b56c3a2457c27d42479e978f4"
+  integrity sha512-dYMdWPTdqNc0fvpk1UajksdlE7uA/KccRr529bobxHNG2y9a5b9DWiNaRt9BwtTFpy2OSgWQqJF+LO/ENwu87w==
   dependencies:
     "@golevelup/ts-jest" "^0.3.4"
     "@nestjs/axios" "0.0.3"


### PR DESCRIPTION
## Main Changes

- Removed values from the `permissionsForFacility` array that are no longer returned from the permissions API (`DPEM`).
- Updated the comment documenting the `EASEY_EMISSIONS_API_CURRENT_USER` environment variable.

## Note
These updates were made while working on https://github.com/US-EPA-CAMD/easey-ui/issues/6102, but they are not needed to resolve that ticket (the actual fix is in [`US-EPA-CAMD/easey-common#137`](https://github.com/US-EPA-CAMD/easey-common/pull/137)).