### PR TITLE
fix: remove duplicates from serveiceValueDate in emissionsImport

### DIFF
--- a/src/emissions-workspace/emissions.service.ts
+++ b/src/emissions-workspace/emissions.service.ts
@@ -32,6 +32,7 @@ import { ReportingPeriod } from '../entities/workspace/reporting-period.entity';
 import { MonitorLocation } from '../entities/monitor-location.entity';
 import { EaseyException } from '@us-epa-camd/easey-common/exceptions/easey.exception';
 import { removeNonReportedValues } from '../utils/remove-non-reported-values';
+import { SummaryValueImportDTO } from 'src/dto/summary-value.dto';
 
 // Import Identifier: Table Id
 export type ImportIdentifiers = {
@@ -365,10 +366,10 @@ export class EmissionsWorkspaceService {
     identifiers: ImportIdentifiers,
     currentTime: string,
   ): Promise<void> {
-    function areDuplicates(elem, other) {
-      return other['parameterCode'] === elem['parameterCode']
-          && ((other['unitId'] !== null && other['unitId'] === elem['unitId'])
-              || (other['stackPipeId'] !== null && other['stackPipeId'] === elem['stackPipeId']))
+    const areDuplicates = (elem: SummaryValueImportDTO, existingElem: SummaryValueImportDTO) => {
+      return existingElem['parameterCode'] === elem['parameterCode']
+          && ((existingElem['unitId'] !== null && existingElem['unitId'] === elem['unitId'])
+              || (existingElem['stackPipeId'] !== null && existingElem['stackPipeId'] === elem['stackPipeId']))
   }
   if (emissionsImport.summaryValueData && emissionsImport.summaryValueData.length>0)
   emissionsImport.summaryValueData = emissionsImport.summaryValueData.reduce((acc, elem) => {

--- a/src/emissions-workspace/emissions.service.ts
+++ b/src/emissions-workspace/emissions.service.ts
@@ -370,7 +370,7 @@ export class EmissionsWorkspaceService {
           && ((other['unitId'] !== null && other['unitId'] === elem['unitId'])
               || (other['stackPipeId'] !== null && other['stackPipeId'] === elem['stackPipeId']))
   }
-  
+  if (emissionsImport.summaryValueData && emissionsImport.summaryValueData.length>0)
   emissionsImport.summaryValueData = emissionsImport.summaryValueData.reduce((acc, elem) => {
       const isDuplicate = acc.some(existingElem => areDuplicates(elem, existingElem));
       if (!isDuplicate) {

--- a/src/emissions-workspace/emissions.service.ts
+++ b/src/emissions-workspace/emissions.service.ts
@@ -365,6 +365,20 @@ export class EmissionsWorkspaceService {
     identifiers: ImportIdentifiers,
     currentTime: string,
   ): Promise<void> {
+    function areDuplicates(elem, other) {
+      return other['parameterCode'] === elem['parameterCode']
+          && ((other['unitId'] !== null && other['unitId'] === elem['unitId'])
+              || (other['stackPipeId'] !== null && other['stackPipeId'] === elem['stackPipeId']))
+  }
+  
+  emissionsImport.summaryValueData = emissionsImport.summaryValueData.reduce((acc, elem) => {
+      const isDuplicate = acc.some(existingElem => areDuplicates(elem, existingElem));
+      if (!isDuplicate) {
+          acc.push(elem)
+      }
+      return acc;
+  }, []);
+
     await this.summaryValueService.import(
       emissionsImport,
       monitoringLocations,


### PR DESCRIPTION
## Pull Request

Resolves [#6100](https://github.com/US-EPA-CAMD/easey-ui/issues/6100) by removing duplicates which violated `uq_summary_value` constraint on camdecmpswks.summary_value table.
