### PR TITLE
Fix/5986 critical error eval status

### DIFF
--- a/src/daily-backstop-workspace/daily-backstop.service.spec.ts
+++ b/src/daily-backstop-workspace/daily-backstop.service.spec.ts
@@ -1,14 +1,16 @@
 import { Test } from '@nestjs/testing';
 import { BulkLoadService } from "@us-epa-camd/easey-common/bulk-load";
+import { faker } from '@faker-js/faker';
+
 import { DailyBackstopWorkspaceService } from "./daily-backstop.service";
 import { ConfigService } from '@nestjs/config';
 import { EmissionsImportDTO } from '../dto/emissions.dto';
 import { genDailyBackstopImportDto } from '../../test/object-generators/daily-backstop-dto';
 import { ImportIdentifiers } from '../emissions-workspace/emissions.service';
-import {DailyBackstopMap} from "../maps/daily-backstop.map";
-import {DailyBackstopWorkspaceRepository} from "./daily-backstop.repository";
-import {DailyBackstop} from "../entities/workspace/daily-backstop.entity";
-import {EmissionsParamsDTO} from "../dto/emissions.params.dto";
+import { DailyBackstopMap } from "../maps/daily-backstop.map";
+import { DailyBackstopWorkspaceRepository } from "./daily-backstop.repository";
+import { DailyBackstop } from "../entities/workspace/daily-backstop.entity";
+import { EmissionsParamsDTO } from "../dto/emissions.params.dto";
 
 describe('Daily Backstop Workspace Service Test', () => {
     let service: DailyBackstopWorkspaceService;
@@ -74,12 +76,9 @@ describe('Daily Backstop Workspace Service Test', () => {
 
             const locations = [{ unit: { name: 'a' }, id: 1 }];
             emissionsDto.dailyBackstopData[0].unitId = 'a';
-            const identifiers = ({
-                components: [],
-                monitorFormulas: [],
-                monitoringSystems: [],
-                userId: '',
-            } as unknown) as ImportIdentifiers;
+            const identifiers = { locations: {}, userId: '' };
+            const monitoringLocationId = faker.datatype.string();
+            identifiers.locations[monitoringLocationId] = { components: {}, monitorFormulas: {}, monitoringSystems: {} };
 
             await expect(service.import(emissionsDto, locations, '', identifiers, ''))
                 .resolves;

--- a/src/daily-emission-workspace/daily-emission-workspace.service.spec.ts
+++ b/src/daily-emission-workspace/daily-emission-workspace.service.spec.ts
@@ -1,4 +1,6 @@
 import { Test, TestingModule } from '@nestjs/testing';
+import { faker } from '@faker-js/faker';
+
 import { DailyEmissionWorkspaceService } from './daily-emission-workspace.service';
 import { DailyEmissionWorkspaceRepository } from './daily-emission-workspace.repository';
 import { DailyFuelWorkspaceService } from '../daily-fuel-workspace/daily-fuel-workspace.service';
@@ -62,7 +64,7 @@ describe('DailyEmissionWorkspaceService', () => {
   });
 
   describe('import', () => {
-    it('should import a record', async function() {
+    it('should import a record', async function () {
       const dailyEmission = genDailyEmission<DailyEmission>(1, {
         include: ['dailyFuelData'],
       });
@@ -80,12 +82,9 @@ describe('DailyEmissionWorkspaceService', () => {
 
       const locations = [{ unit: { name: 'a' }, id: 1 }];
       importData[0].unitId = 'a';
-      const identifiers = ({
-        components: [],
-        monitorFormulas: [],
-        monitoringSystems: [],
-        userId: '',
-      } as unknown) as ImportIdentifiers;
+      const identifiers = { locations: {}, userId: '' };
+      const monitoringLocationId = faker.datatype.string();
+      identifiers.locations[monitoringLocationId] = { components: {}, monitorFormulas: {}, monitoringSystems: {} };
 
       await expect(service.import(emissionsDto, locations, '', identifiers, ''))
         .resolves;

--- a/src/daily-test-summary-workspace/daily-test-summary.service.spec.ts
+++ b/src/daily-test-summary-workspace/daily-test-summary.service.spec.ts
@@ -1,4 +1,5 @@
 import { Test, TestingModule } from '@nestjs/testing';
+import { faker } from '@faker-js/faker';
 import { DailyCalibrationMap } from '../maps/daily-calibration.map';
 import { DailyTestSummaryWorkspaceService } from './daily-test-summary.service';
 import { DailyTestSummaryWorkspaceRepository } from './daily-test-summary.repository';
@@ -117,16 +118,15 @@ describe('Daily Summary Workspace Service', () => {
       new DailyTestSummaryImportDTO(),
     ];
 
+    const identifiers = { locations: {}, userId: '' };
+    const monitoringLocationId = faker.datatype.string();
+    identifiers.locations[monitoringLocationId] = { components: {}, monitorFormulas: {}, monitoringSystems: {} };
+
     await dailyTestSummaryService.import(
       emissionsDto,
       [new MonitorLocation()],
       1,
-      {
-        components: {},
-        monitorFormulas: {},
-        monitoringSystems: {},
-        userId: '',
-      },
+      identifiers,
       new Date().toISOString(),
     );
 

--- a/src/daily-test-summary-workspace/daily-test-summary.service.ts
+++ b/src/daily-test-summary-workspace/daily-test-summary.service.ts
@@ -123,7 +123,7 @@ export class DailyTestSummaryWorkspaceService {
         rptPeriodId: reportingPeriodId,
         monLocId: monitoringLocationId,
         componentId:
-          identifiers?.components?.[dailyTestSummaryDatum.componentId] || null,
+          identifiers?.locations[monitoringLocationId]?.components?.[dailyTestSummaryDatum.componentId] || null,
         dailyTestDate: dailyTestSummaryDatum.date,
         dailyTestHour: dailyTestSummaryDatum.hour,
         dailyTestMin: dailyTestSummaryDatum.minute,
@@ -134,7 +134,7 @@ export class DailyTestSummaryWorkspaceService {
         updateDate: currentTime,
         spanScaleCd: dailyTestSummaryDatum.spanScaleCode,
         monSysId:
-          identifiers?.monitoringSystems?.[dailyTestSummaryDatum.monitoringSystemId] || null,
+          identifiers?.locations[monitoringLocationId]?.monitoringSystems?.[dailyTestSummaryDatum.monitoringSystemId] || null,
       });
     }
 

--- a/src/derived-hourly-value-workspace/derived-hourly-value-workspace.service.ts
+++ b/src/derived-hourly-value-workspace/derived-hourly-value-workspace.service.ts
@@ -42,9 +42,9 @@ export class DerivedHourlyValueWorkspaceService {
         id: randomUUID(),
         hourId: hourId,
         monSysId:
-          identifiers?.monitoringSystems?.[dataChunk.monitoringSystemId] || null,
+          identifiers?.locations[monitorLocationId]?.monitoringSystems?.[dataChunk.monitoringSystemId] || null,
         monFormId:
-          identifiers?.monitorFormulas?.[dataChunk.formulaId] || null,
+          identifiers?.locations[monitorLocationId]?.monitorFormulas?.[dataChunk.formulaId] || null,
         parameterCode: dataChunk.parameterCode,
         unadjustedHrlyValue: dataChunk.unadjustedHourlyValue,
         adjustedHourlyValue: dataChunk.adjustedHourlyValue,

--- a/src/emissions-workspace/emissions.service.spec.ts
+++ b/src/emissions-workspace/emissions.service.spec.ts
@@ -101,9 +101,9 @@ import { BulkLoadModule } from '@us-epa-camd/easey-common/bulk-load';
 import { MonitorLocation } from '../entities/monitor-location.entity';
 import { ConfigService } from '@nestjs/config';
 import { DailyBackstopWorkspaceModule } from '../daily-backstop-workspace/daily-backstop.module';
-import {DailyBackstopWorkspaceRepository} from "../daily-backstop-workspace/daily-backstop.repository";
-import {DailyBackstopMap} from "../maps/daily-backstop.map";
-import {DailyBackstopWorkspaceService} from "../daily-backstop-workspace/daily-backstop.service";
+import { DailyBackstopWorkspaceRepository } from "../daily-backstop-workspace/daily-backstop.repository";
+import { DailyBackstopMap } from "../maps/daily-backstop.map";
+import { DailyBackstopWorkspaceService } from "../daily-backstop-workspace/daily-backstop.service";
 import { CodeChecksService } from '../code-checks/code-checks.service';
 
 describe('Emissions Workspace Service', () => {
@@ -246,7 +246,7 @@ describe('Emissions Workspace Service', () => {
         {
           provide: DailyBackstopWorkspaceRepository,
           useValue: jest.mock(
-              '../daily-backstop-workspace/daily-backstop.repository',
+            '../daily-backstop-workspace/daily-backstop.repository',
           ),
         },
       ],
@@ -261,17 +261,17 @@ describe('Emissions Workspace Service', () => {
     plantRepository = module.get(PlantRepository);
   });
 
-  it('should have a emissions service', function() {
+  it('should have a emissions service', function () {
     expect(emissionsService).toBeDefined();
   });
 
-  it('should delete a record', async function() {
+  it('should delete a record', async function () {
     await expect(
       emissionsService.delete({ monitorPlanId: '123', reportingPeriodId: 2 }),
     ).resolves.toEqual(undefined);
   });
 
-  it('should successfully export emissions data', async function() {
+  it('should successfully export emissions data', async function () {
     const emissionsMocks = genEmissionEvaluation<EmissionEvaluation>();
     const dtoMocks = genEmissionsRecordDto();
 
@@ -284,7 +284,7 @@ describe('Emissions Workspace Service', () => {
     );
   });
 
-  it('should successfully import', async function() {
+  it('should successfully import', async function () {
     jest.spyOn(longTermFuelFlowService, 'import').mockResolvedValue(undefined);
     jest.spyOn(typeorm_functions, 'getManager').mockReturnValue(({
       findOne: jest.fn().mockResolvedValue(new ReportingPeriod()),
@@ -319,7 +319,7 @@ describe('Emissions Workspace Service', () => {
     );
   });
 
-  it('should import daily test summaries', async function() {
+  it('should import daily test summaries', async function () {
     const emissionsDtoMock = genEmissionsImportDto();
     const dtoMockWithDailyTest = genEmissionsImportDto(1, {
       include: ['dailyTestSummaryData'],
@@ -329,12 +329,15 @@ describe('Emissions Workspace Service', () => {
     jest.spyOn(dailyTestsummaryService, 'import').mockReturnValue(undefined);
 
     const monitoringLocation = new MonitorLocation();
+    const identifiers = { locations: {}, userId: '' };
+    const monitoringLocationId = faker.datatype.string();
+    identifiers.locations[monitoringLocationId] = { components: {}, monitorFormulas: {}, monitoringSystems: {} };
     await expect(
       emissionsService.importDailyTestSummaries(
         emissionsDtoMock[0],
         [monitoringLocation],
         faker.datatype.number(),
-        { monitoringSystems: {}, components: {}, monitorFormulas: {} },
+        identifiers,
         new Date().toISOString(),
       ),
     ).resolves.toBeUndefined();
@@ -344,7 +347,7 @@ describe('Emissions Workspace Service', () => {
         dtoMockWithDailyTest[0],
         [monitoringLocation],
         faker.datatype.number(),
-        { monitoringSystems: {}, components: {}, monitorFormulas: {} },
+        identifiers,
         new Date().toISOString(),
       ),
     ).resolves;

--- a/src/hourly-fuel-flow-workspace/hourly-fuel-flow-workspace.service.ts
+++ b/src/hourly-fuel-flow-workspace/hourly-fuel-flow-workspace.service.ts
@@ -87,7 +87,7 @@ export class HourlyFuelFlowWorkspaceService {
         id: uid,
         hourId,
         monitoringSystemId:
-          identifiers.monitoringSystems?.[dataChunk.monitoringSystemId] || null,
+          identifiers?.locations[monitorLocationId]?.monitoringSystems?.[dataChunk.monitoringSystemId] || null,
         fuelCode: dataChunk.fuelCode,
         fuelUsageTime: dataChunk.fuelUsageTime,
         volumetricFlowRate: dataChunk.volumetricFlowRate,

--- a/src/hourly-gas-flow-meter-workspace/hourly-gas-flow-meter.service.ts
+++ b/src/hourly-gas-flow-meter-workspace/hourly-gas-flow-meter.service.ts
@@ -41,7 +41,7 @@ export class HourlyGasFlowMeterWorkspaceService {
         hourId,
         monitorLocationId,
         reportingPeriodId,
-        componentId: identifiers?.components?.[dataChunk.componentId],
+        componentId: identifiers?.locations[monitorLocationId]?.components?.[dataChunk.componentId],
         beginEndHourFlag: dataChunk.beginEndHourFlag,
         hourlyGfmReading: dataChunk.hourlyGFMReading,
         avgHourlySamplingRate: dataChunk.averageHourlySamplingRate,

--- a/src/hourly-operating-workspace/hourly-operating.service.spec.ts
+++ b/src/hourly-operating-workspace/hourly-operating.service.spec.ts
@@ -1,4 +1,5 @@
 import { Test } from '@nestjs/testing';
+import { faker } from '@faker-js/faker';
 
 import {
   HourlyOperatingWorkspaceService,
@@ -221,16 +222,15 @@ describe('HourlyOperatingWorskpaceService', () => {
         new HourlyOperatingImportDTO(),
       ];
 
+      const identifiers = { locations: {}, userId: '' };
+      const monitoringLocationId = faker.datatype.string();
+      identifiers.locations[monitoringLocationId] = { components: {}, monitorFormulas: {}, monitoringSystems: {} };
+
       await service.import(
         dto,
         [MonitorLocation],
         1,
-        {
-          components: {},
-          userId: '',
-          monitorFormulas: {},
-          monitoringSystems: {},
-        },
+        identifiers,
         new Date().toISOString(),
       );
 

--- a/src/hourly-parameter-fuel-flow-workspace/hourly-parameter-fuel-flow-workspace.service.ts
+++ b/src/hourly-parameter-fuel-flow-workspace/hourly-parameter-fuel-flow-workspace.service.ts
@@ -38,9 +38,9 @@ export class HourlyParameterFuelFlowWorkspaceService {
         id: randomUUID(),
         parentId: parentId,
         monitoringSystemId:
-          identifiers.monitoringSystems?.[dataChunk.monitoringSystemId] || null,
+          identifiers?.locations[monitorLocationId]?.monitoringSystems?.[dataChunk.monitoringSystemId] || null,
         formulaIdentifier:
-          identifiers.monitorFormulas?.[dataChunk.formulaId] || null,
+          identifiers?.locations[monitorLocationId]?.monitorFormulas?.[dataChunk.formulaId] || null,
         parameterCode: dataChunk.parameterCode,
         parameterValueForFuel: dataChunk.parameterValueForFuel,
         sampleTypeCode: dataChunk.sampleTypeCode,

--- a/src/long-term-fuel-flow-workspace/long-term-fuel-flow.service.spec.ts
+++ b/src/long-term-fuel-flow-workspace/long-term-fuel-flow.service.spec.ts
@@ -1,4 +1,6 @@
 import { Test } from '@nestjs/testing';
+import { faker } from '@faker-js/faker';
+
 import { mockLongTermFuelFlowWorkspaceRepository } from '../../test/mocks/mock-long-term-fuel-flow-workspace-repository';
 import { LongTermFuelFlowWorkspaceRepository } from './long-term-fuel-flow.repository';
 import { LongTermFuelFlowWorkspaceService } from './long-term-fuel-flow.service';
@@ -57,18 +59,15 @@ describe('--LongTermFuelFlowWorkspaceService--', () => {
     const locations = [{ unit: { name: '1' }, id: 1 }];
 
     longTermFuelFlow[0].unitId = '1';
-    const identifiers = ({
-      components: [],
-      monitorFormulas: [],
-      monitoringSystems: [],
-      userId: '',
-    } as unknown) as ImportIdentifiers;
+    const identifiers = { locations: {}, userId: '' };
+    const monitoringLocationId = faker.datatype.string();
+    identifiers.locations[monitoringLocationId] = { components: {}, monitorFormulas: {}, monitoringSystems: {} };
 
     await expect(
       service.import(emissionsDto, locations, '1', identifiers, '2019-01-01'),
     ).resolves;
   });
-  it('should get long term fuel flow by location ids', async function() {
+  it('should get long term fuel flow by location ids', async function () {
     const genLongTermFuelFlowValues = genLongTermFuelFlow<LongTermFuelFlow>(1);
     const promises = [];
     genLongTermFuelFlowValues.forEach(value => {

--- a/src/long-term-fuel-flow-workspace/long-term-fuel-flow.service.ts
+++ b/src/long-term-fuel-flow-workspace/long-term-fuel-flow.service.ts
@@ -86,7 +86,7 @@ export class LongTermFuelFlowWorkspaceService {
         reportingPeriodId: reportingPeriodId,
         monLocId: monitoringLocationId,
         monSysId:
-          identifiers?.monitoringSystems?.[
+          identifiers?.locations[monitoringLocationId]?.monitoringSystems?.[
             longTermFuelFlowDatum.monitoringSystemId
           ] || null,
         fuelFlowPeriodCd: longTermFuelFlowDatum.fuelFlowPeriodCode,

--- a/src/mats-derived-hourly-value-workspace/mats-derived-hourly-value.service.ts
+++ b/src/mats-derived-hourly-value-workspace/mats-derived-hourly-value.service.ts
@@ -43,7 +43,7 @@ export class MatsDerivedHourlyValueWorkspaceService {
         unadjustedHourlyValue: dataChunk.unadjustedHourlyValue,
         modcCode: dataChunk.modcCode,
         monFormId:
-          identifiers?.monitorFormulas?.[dataChunk.formulaId] || null,
+          identifiers?.locations[monitorLocationId]?.monitorFormulas?.[dataChunk.formulaId] || null,
         monLoc: monitorLocationId,
         rptPeriod: reportingPeriodId,
         userId: identifiers?.userId,

--- a/src/mats-monitor-hourly-value-workspace/mats-monitor-hourly-value.service.ts
+++ b/src/mats-monitor-hourly-value-workspace/mats-monitor-hourly-value.service.ts
@@ -44,8 +44,8 @@ export class MatsMonitorHourlyValueWorkspaceService {
         reportingPeriodId: reportingPeriodId,
         parameterCode: dataChunk.parameterCode,
         monitoringSystemId:
-          identifiers.monitoringSystems?.[dataChunk.monitoringSystemId] || null,
-        componentId: identifiers.components?.[dataChunk.componentId] || null,
+          identifiers.locations[monitorLocationId]?.monitoringSystems?.[dataChunk.monitoringSystemId] || null,
+        componentId: identifiers.locations[monitorLocationId]?.components?.[dataChunk.componentId] || null,
         unadjustedHourlyValue: dataChunk.unadjustedHourlyValue,
         modcCode: dataChunk.modcCode,
         percentAvailable: dataChunk.percentAvailable,

--- a/src/monitor-hourly-value-workspace/monitor-hourly-value.service.ts
+++ b/src/monitor-hourly-value-workspace/monitor-hourly-value.service.ts
@@ -41,9 +41,9 @@ export class MonitorHourlyValueWorkspaceService {
         id: randomUUID(),
         hourId,
         monitoringSystemId:
-          identifiers.monitoringSystems?.[dataChunk.monitoringSystemId] || null,
+          identifiers.locations[monitorLocationId]?.monitoringSystems?.[dataChunk.monitoringSystemId] || null,
         componentId:
-          identifiers.components?.[dataChunk.componentId] || null,
+          identifiers.locations[monitorLocationId]?.components?.[dataChunk.componentId] || null,
         parameterCode: dataChunk.parameterCode,
         unadjustedHourlyValue: dataChunk.unadjustedHourlyValue,
         adjustedHourlyValue: dataChunk.adjustedHourlyValue,

--- a/src/nsps4t-annual-functions/import-nsps4t-annual-data.spec.ts
+++ b/src/nsps4t-annual-functions/import-nsps4t-annual-data.spec.ts
@@ -11,12 +11,16 @@ describe('ImportNsps4tAnnualData', () => {
     importNsps4tAnnualModule = await import('./import-nsps4t-annual-data');
   });
 
-  it('should import data', async function() {
+  it('should import data', async function () {
     const imports = [...genNsps4tAnnualImportDto(3)];
 
     // @ts-expect-error force as undefined
     jest.spyOn(repository, 'create').mockResolvedValue(undefined);
     jest.spyOn(repository, 'save').mockResolvedValue(undefined);
+
+    const identifiers = { locations: {}, userId: '' };
+    const monitoringLocationId = faker.datatype.string();
+    identifiers.locations[monitoringLocationId] = { components: {}, monitorFormulas: {}, monitoringSystems: {} };
 
     await Promise.all(
       imports.map(data => {
@@ -27,11 +31,7 @@ describe('ImportNsps4tAnnualData', () => {
               monitoringLocationId: faker.datatype.string(),
               reportingPeriodId: faker.datatype.number(),
               nsps4tSumId: faker.datatype.string(),
-              identifiers: {
-                monitoringSystems: {},
-                components: {},
-                monitorFormulas: {},
-              },
+              identifiers,
             },
             repository,
           }),

--- a/src/nsps4t-compliance-period-functions/import-nsps4t-compliance-period-data.spec.ts
+++ b/src/nsps4t-compliance-period-functions/import-nsps4t-compliance-period-data.spec.ts
@@ -20,6 +20,10 @@ describe('ImportNsps4tCompliancePeriodData', () => {
     jest.spyOn(repository, 'create').mockResolvedValue(undefined);
     jest.spyOn(repository, 'save').mockResolvedValue(undefined);
 
+    const identifiers = { locations: {}, userId: '' };
+    const monitoringLocationId = faker.datatype.string();
+    identifiers.locations[monitoringLocationId] = { components: {}, monitorFormulas: {}, monitoringSystems: {} };
+
     await Promise.all(
       imports.map(data => {
         expect(
@@ -29,11 +33,7 @@ describe('ImportNsps4tCompliancePeriodData', () => {
               monitoringLocationId: faker.datatype.string(),
               reportingPeriodId: faker.datatype.number(),
               nsps4tSumId: faker.datatype.string(),
-              identifiers: {
-                monitoringSystems: {},
-                components: {},
-                monitorFormulas: {},
-              },
+              identifiers,
             },
             repository,
           }),

--- a/src/nsps4t-summary-functions/import-nsps4t-summary-data.spec.ts
+++ b/src/nsps4t-summary-functions/import-nsps4t-summary-data.spec.ts
@@ -11,7 +11,7 @@ describe('ImportNsps4tSummaryData', () => {
     importNsps4tSummaryModule = await import('./import-nsps4t-summary-data');
   });
 
-  it('should import data', async function() {
+  it('should import data', async function () {
     const imports = [
       ...genNsps4tSummaryImportDto(),
       ...genNsps4tSummaryImportDto(1, { include: ['nsps4tFourthQuarterData'] }),
@@ -28,6 +28,10 @@ describe('ImportNsps4tSummaryData', () => {
     jest.spyOn(repository, 'save').mockResolvedValue(undefined);
     jest.spyOn(repository, 'delete').mockResolvedValue(undefined);
 
+    const identifiers = { locations: {}, userId: '' };
+    const monitoringLocationId = faker.datatype.string();
+    identifiers.locations[monitoringLocationId] = { components: {}, monitorFormulas: {}, monitoringSystems: {} };
+
     await Promise.all(
       imports.map(data => {
         expect(
@@ -36,11 +40,7 @@ describe('ImportNsps4tSummaryData', () => {
               ...data,
               monitoringLocationId: faker.datatype.string(),
               reportingPeriodId: faker.datatype.number(),
-              identifiers: {
-                monitorFormulas: {},
-                components: {},
-                monitoringSystems: {},
-              },
+              identifiers,
             },
             repository,
           }),

--- a/src/nsps4t-summary-workspace/nsps4t-summary-workspace.service.spec.ts
+++ b/src/nsps4t-summary-workspace/nsps4t-summary-workspace.service.spec.ts
@@ -1,4 +1,6 @@
 import { Test, TestingModule } from '@nestjs/testing';
+import { faker } from '@faker-js/faker';
+
 import { Nsps4tSummaryWorkspaceService } from './nsps4t-summary-workspace.service';
 import { Nsps4tSummaryWorkspaceRepository } from './nsps4t-summary-workspace.repository';
 import { Nsps4tAnnualWorkspaceService } from '../nsps4t-annual-workspace/nsps4t-annual-workspace.service';
@@ -71,7 +73,7 @@ describe('Nsps4tSummaryWorkspaceNewService', () => {
     );
   });
 
-  it('should successfully import', async function() {
+  it('should successfully import', async function () {
     const entityMocks = genNsps4tSummary<Nsps4tSummary>(1, {
       include: ['nsps4tAnnualData', 'nsps4tCompliancePeriodData'],
       nsps4tCompliancePeriodDataAmount: 1,
@@ -92,12 +94,9 @@ describe('Nsps4tSummaryWorkspaceNewService', () => {
     const locations = [{ unit: { name: '1' }, id: 1 }];
 
     nsps4tSummaryData[0].unitId = '1';
-    const identifiers = ({
-      components: [],
-      monitorFormulas: [],
-      monitoringSystems: [],
-      userId: '',
-    } as unknown) as ImportIdentifiers;
+    const identifiers = { locations: {}, userId: '' };
+    const monitoringLocationId = faker.datatype.string();
+    identifiers.locations[monitoringLocationId] = { components: {}, monitorFormulas: {}, monitoringSystems: {} };
 
     await expect(
       service.import(emissionsDto, locations, '1', identifiers, '2019-01-01'),

--- a/src/sampling-train-functions/import-sampling-train-data.spec.ts
+++ b/src/sampling-train-functions/import-sampling-train-data.spec.ts
@@ -18,6 +18,10 @@ describe('ImportSamplingTrainData', () => {
     jest.spyOn(repository, 'create').mockResolvedValue(undefined);
     jest.spyOn(repository, 'save').mockResolvedValue(undefined);
 
+    const identifiers = { locations: {}, userId: '' };
+    const monitoringLocationId = faker.datatype.string();
+    identifiers.locations[monitoringLocationId] = { components: {}, monitorFormulas: {}, monitoringSystems: {} };
+
     await Promise.all(
       importReturn.map(data => {
         expect(
@@ -27,11 +31,7 @@ describe('ImportSamplingTrainData', () => {
               sorbentTrapId: faker.datatype.string(),
               reportingPeriodId: faker.datatype.number(),
               monitoringLocationId: faker.datatype.string(),
-              identifiers: {
-                monitorFormulas: {},
-                monitoringSystems: {},
-                components: {},
-              },
+              identifiers,
             },
             repository,
           }),

--- a/src/sampling-train-functions/import-sampling-train-data.ts
+++ b/src/sampling-train-functions/import-sampling-train-data.ts
@@ -25,7 +25,7 @@ export const importSamplingTrainData = async ({
       sorbentTrapId: data.sorbentTrapId,
       monitoringLocationId: data.monitoringLocationId,
       reportingPeriodId: data.reportingPeriodId,
-      componentId: data.identifiers?.components?.[data.componentId],
+      componentId: data.identifiers?.locations[data.monitoringLocationId]?.components?.[data.componentId],
       sorbentTrapSn: data.sorbentTrapSN,
       mainTrapHg: data.mainTrapHg,
       btTrapHg: data.btTrapHg,

--- a/src/sampling-train-workspace/sampling-train-workspace.service.ts
+++ b/src/sampling-train-workspace/sampling-train-workspace.service.ts
@@ -36,7 +36,7 @@ export class SamplingTrainWorkspaceService {
         trapId: sorbentTrapId,
         monLocId: monitoringLocationId,
         rptPeriodId: reportingPeriodId,
-        componentId: identifiers?.components?.[dataChunk.componentId] || null,
+        componentId: identifiers?.locations[monitoringLocationId]?.components?.[dataChunk.componentId] || null,
         sorbentTrapSerialNumber: dataChunk.sorbentTrapSN,
         mainTrapHg: dataChunk.mainTrapHg,
         breakthroughTrapHg: dataChunk.btTrapHg,

--- a/src/sorbent-trap-functions/import-sorbent-trap-data.spec.ts
+++ b/src/sorbent-trap-functions/import-sorbent-trap-data.spec.ts
@@ -11,7 +11,7 @@ describe('ImportSorbentTrapData', () => {
     importSorbentTrapModule = await import('./import-sorbent-trap-data');
   });
 
-  it('should import data', async function() {
+  it('should import data', async function () {
     const importReturn = [
       ...genSorbentTrapImportDto(3),
       ...genSorbentTrapImportDto(3, { include: ['samplingTrainData'] }),
@@ -24,17 +24,16 @@ describe('ImportSorbentTrapData', () => {
 
     await Promise.all(
       importReturn.map(data => {
+        const identifiers = { locations: {}, userId: '' };
+        const monitoringLocationId = faker.datatype.string();
+        identifiers.locations[monitoringLocationId] = { components: {}, monitorFormulas: {}, monitoringSystems: {} };
         expect(
           importSorbentTrapModule.importSorbentTrapData({
             data: {
               ...data,
               reportingPeriodId: faker.datatype.number(),
-              monitoringLocationId: faker.datatype.string(),
-              identifiers: {
-                monitoringSystems: {},
-                monitorFormulas: {},
-                components: {},
-              },
+              monitoringLocationId: monitoringLocationId,
+              identifiers,
             },
             repository,
           }),

--- a/src/sorbent-trap-functions/import-sorbent-trap-data.ts
+++ b/src/sorbent-trap-functions/import-sorbent-trap-data.ts
@@ -27,7 +27,7 @@ export const importSorbentTrapData = async ({
     endDate: data.endDate,
     endHour: data.endHour,
     monitoringSystemId:
-      data.identifiers?.monitoringSystems?.[data.monitoringSystemId],
+      data.identifiers?.locations[data.monitoringLocationId]?.monitoringSystems?.[data.monitoringSystemId],
     pairedTrapAgreement: data.pairedTrapAgreement,
     absoluteDifferenceIndicator: data.absoluteDifferenceIndicator,
     modcCode: data.modcCode,

--- a/src/sorbent-trap-workspace/sorbent-trap-workspace.service.spec.ts
+++ b/src/sorbent-trap-workspace/sorbent-trap-workspace.service.spec.ts
@@ -1,4 +1,6 @@
 import { Test, TestingModule } from '@nestjs/testing';
+import { faker } from '@faker-js/faker';
+
 import { SorbentTrapWorkspaceService } from './sorbent-trap-workspace.service';
 import { SamplingTrainWorkspaceService } from '../sampling-train-workspace/sampling-train-workspace.service';
 import { SamplingTrainWorkspaceRepository } from '../sampling-train-workspace/sampling-train-workspace.repository';
@@ -67,7 +69,7 @@ describe('SorbentTrapWorkspaceService', () => {
     );
   });
 
-  it('should successfully import', async function() {
+  it('should successfully import', async function () {
     const mockedValues = genSorbentTrap<SorbentTrap>(1, {
       include: ['samplingTrains'],
       samplingTrainAmount: 1,
@@ -86,12 +88,9 @@ describe('SorbentTrapWorkspaceService', () => {
     const locations = [{ unit: { name: '1' }, id: 1 }];
 
     sorbentTrapData[0].unitId = '1';
-    const identifiers = ({
-      components: [],
-      monitorFormulas: [],
-      monitoringSystems: [],
-      userId: '',
-    } as unknown) as ImportIdentifiers;
+    const identifiers = { locations: {}, userId: '' };
+    const monitoringLocationId = faker.datatype.string();
+    identifiers.locations[monitoringLocationId] = { components: {}, monitorFormulas: {}, monitoringSystems: {} };
 
     await expect(
       service.import(emissionsDto, locations, '1', identifiers, '2019-01-01'),

--- a/src/sorbent-trap-workspace/sorbent-trap-workspace.service.ts
+++ b/src/sorbent-trap-workspace/sorbent-trap-workspace.service.ts
@@ -104,7 +104,7 @@ export class SorbentTrapWorkspaceService {
         endDate: sorbentTrapDatum.endDate,
         endHour: sorbentTrapDatum.endHour,
         monSysId:
-          identifiers?.monitoringSystems?.[
+          identifiers?.locations[monitoringLocationId]?.monitoringSystems?.[
             sorbentTrapDatum.monitoringSystemId
           ] || null,
         pairedTrapAgreement: sorbentTrapDatum.pairedTrapAgreement,

--- a/src/summary-value-workspace/summary-value.service.spec.ts
+++ b/src/summary-value-workspace/summary-value.service.spec.ts
@@ -1,4 +1,6 @@
 import { Test } from '@nestjs/testing';
+import { faker } from '@faker-js/faker';
+
 import { SummaryValueWorkspaceService } from './summary-value.service';
 import { SummaryValueMap } from '../maps/summary-value.map';
 import { SummaryValueWorkspaceRepository } from './summary-value.repository';
@@ -62,12 +64,9 @@ describe('Summary Value Workspace Service Test', () => {
 
       const locations = [{ unit: { name: 'a' }, id: 1 }];
       emissionsDto.summaryValueData[0].unitId = 'a';
-      const identifiers = ({
-        components: [],
-        monitorFormulas: [],
-        monitoringSystems: [],
-        userId: '',
-      } as unknown) as ImportIdentifiers;
+      const identifiers = { locations: {}, userId: '' };
+      const monitoringLocationId = faker.datatype.string();
+      identifiers.locations[monitoringLocationId] = { components: {}, monitorFormulas: {}, monitoringSystems: {} };
 
       await expect(service.import(emissionsDto, locations, '', identifiers, ''))
         .resolves;

--- a/src/weekly-test-summary-workspace/weekly-test-summary.service.spec.ts
+++ b/src/weekly-test-summary-workspace/weekly-test-summary.service.spec.ts
@@ -1,4 +1,5 @@
 import { Test } from '@nestjs/testing';
+import { faker } from '@faker-js/faker';
 
 import { WeeklyTestSummaryMap } from '../maps/weekly-test-summary.map';
 import { WeeklyTestSummaryWorkspaceRepository } from './weekly-test-summary.repository';
@@ -101,12 +102,9 @@ describe('--WeeklyTestSummaryWorkspaceService--', () => {
 
       const locations = [{ unit: { name: 'a' }, id: 1 }];
       importData[0].unitId = 'a';
-      const identifiers = ({
-        components: [],
-        monitorFormulas: [],
-        monitoringSystems: [],
-        userId: '',
-      } as unknown) as ImportIdentifiers;
+      const identifiers = { locations: {}, userId: '' };
+      const monitoringLocationId = faker.datatype.string();
+      identifiers.locations[monitoringLocationId] = { components: {}, monitorFormulas: {}, monitoringSystems: {} };
 
       await expect(service.import(emissionsDto, locations, '', identifiers, ''))
         .resolves;

--- a/src/weekly-test-summary-workspace/weekly-test-summary.service.ts
+++ b/src/weekly-test-summary-workspace/weekly-test-summary.service.ts
@@ -131,7 +131,7 @@ export class WeeklyTestSummaryWorkspaceService {
         uid,
         reportingPeriodId,
         monitoringLocationId,
-        componentId: identifiers?.components?.[componentId] || null,
+        componentId: identifiers?.locations[monitoringLocationId]?.components?.[componentId] || null,
         date,
         hour,
         minute,


### PR DESCRIPTION
## Ticket
[Critical errors in Eval status and no errors shown in report](https://github.com/US-EPA-CAMD/easey-ui/issues/5986)

## Changes

- used  `identifiers.locations[locationId]` instead of just `identifiers`
-  changed the `buildObjectList()` versions that use "identifiers" to use `identifiers.locations[monitorLocationId]` instead