### PR TITLE
fix(6185): addressed return value changing from undefined to null

### DIFF
--- a/src/emissions/emissions.service.ts
+++ b/src/emissions/emissions.service.ts
@@ -18,7 +18,7 @@ import { SummaryValueService } from '../summary-value/summary-value.service';
 import { Nsps4tSummaryService } from '../nsps4t-summary/nsps4t-summary.service';
 import { LongTermFuelFlowService } from '../long-term-fuel-flow/long-term-fuel-flow.service';
 import { removeNonReportedValues } from '../utils/remove-non-reported-values';
-import {DailyBackstopService} from "../daily-backstop/daily-backstop.service";
+import { DailyBackstopService } from '../daily-backstop/daily-backstop.service';
 
 const moment = require('moment');
 
@@ -81,7 +81,8 @@ export class EmissionsService {
       results.hourlyOperatingData = promiseResult[HOURLY_OPERATING] ?? [];
       results.dailyEmissionData = promiseResult[DAILY_EMISSION] ?? [];
       results.sorbentTrapData = promiseResult[SORBENT_TRAP] ?? [];
-      results.weeklyTestSummaryData = promiseResult[WEEKLY_TEST_SUMMARIES] ?? [];
+      results.weeklyTestSummaryData =
+        promiseResult[WEEKLY_TEST_SUMMARIES] ?? [];
       results.summaryValueData = promiseResult[SUMMARY_VALUES] ?? [];
       results.nsps4tSummaryData = promiseResult[NSPS4T_SUMMARY] ?? [];
       results.longTermFuelFlowData = promiseResult[LONG_TERM_FUEL_FLOW] ?? [];
@@ -108,7 +109,7 @@ export class EmissionsService {
     const date = moment(periodDate);
     const month = date.get('month') + 1;
 
-    if (queryResult === undefined) {
+    if (!queryResult) {
       if (
         ['development', 'test', 'local-dev'].includes(
           this.configService.get<string>('app.env'),


### PR DESCRIPTION
## Changes

In the previous changes made in response to the TypeORM update, I overlooked one breaking change noted in the [release notes](https://github.com/typeorm/typeorm/releases/tag/0.3.0):
> findOne and QueryBuilder.getOne() now return null instead of undefined in the case if it didn't find anything in the database.
Logically it makes more sense to return null.

This means that all explicit comparisons against `undefined` should be changed to `null` (alternatively, since the method will return either a complex type or `null`, one can just check if it is falsy).