### PR TITLE
Hourly records in emissions exports are not sorted correctly

### DIFF
--- a/src/daily-test-summary/daily-test-summary.repository.ts
+++ b/src/daily-test-summary/daily-test-summary.repository.ts
@@ -21,7 +21,11 @@ export class DailyTestSummaryRepository extends Repository<DailyTestSummary> {
         monitoringLocationIds: monitoringLocationIds,
       })
       .andWhere('r.year = :year ', { year })
-      .andWhere('r.quarter = :quarter ', { quarter });
+      .andWhere('r.quarter = :quarter ', { quarter })
+      .orderBy({
+        'dts.date': 'ASC',
+        'dts.hour': 'ASC'
+      });
 
     return query.getMany();
   }

--- a/src/hourly-operating/hourly-operating.repository.spec.ts
+++ b/src/hourly-operating/hourly-operating.repository.spec.ts
@@ -31,6 +31,7 @@ describe('-- HourlyOperatingRepository --', () => {
     queryBuilder.leftJoinAndSelect.mockReturnValue(queryBuilder);
     queryBuilder.where.mockReturnValue(queryBuilder);
     queryBuilder.andWhere.mockReturnValue(queryBuilder);
+    queryBuilder.orderBy.mockReturnValue(queryBuilder);
     queryBuilder.getMany.mockReturnValue('mockHourlyOperating');
   });
 

--- a/src/hourly-operating/hourly-operating.repository.ts
+++ b/src/hourly-operating/hourly-operating.repository.ts
@@ -19,7 +19,11 @@ export class HourlyOperatingRepository extends Repository<HrlyOpData> {
         monitoringLocationIds: monitoringLocationIds,
       })
       .andWhere('r.year = :year ', { year })
-      .andWhere('r.quarter = :quarter ', { quarter });
+      .andWhere('r.quarter = :quarter ', { quarter })
+      .orderBy({
+        'hod.date': 'ASC',
+        'hod.hour': 'ASC'
+      });
 
     return query.getMany();
   }

--- a/test/mocks/mock-query-builder.ts
+++ b/test/mocks/mock-query-builder.ts
@@ -7,4 +7,5 @@ export const mockQueryBuilder = {
   andWhere: jest.fn(),
   getMany: jest.fn(),
   getOne: jest.fn(),
+  orderBy: jest.fn(),
 };


### PR DESCRIPTION
Ticket
https://github.com/US-EPA-CAMD/easey-ui/issues/6188

Changes
Added the orderBy clause to dailyTestSummaryData and hourlyOperatingData records.