### PR TITLE
6194-Emissions data should be exported in the right order

### DIFF
--- a/src/daily-backstop/daily-backstop.service.spec.ts
+++ b/src/daily-backstop/daily-backstop.service.spec.ts
@@ -39,6 +39,7 @@ describe('Daily Backstop Service Test', () => {
         innerJoin: () => mockQueryBuilder,
         where: () => mockQueryBuilder,
         andWhere: () => mockQueryBuilder,
+        orderBy: () => mockQueryBuilder,
         getMany: jest
           .fn()
           .mockResolvedValue([new DailyBackstop(), new DailyBackstop()]),

--- a/src/daily-backstop/daily-backstop.service.ts
+++ b/src/daily-backstop/daily-backstop.service.ts
@@ -23,6 +23,9 @@ export class DailyBackstopService {
             })
             .andWhere('reportingPeriod.year = :year', { year: params.year })
             .andWhere('reportingPeriod.quarter = :quarter', { quarter: params.quarter })
+            .orderBy({
+                'backstop.date': 'ASC',
+            })
             .getMany();
 
         if (!results) {

--- a/src/daily-emission-functions/export-daily-emission-data.ts
+++ b/src/daily-emission-functions/export-daily-emission-data.ts
@@ -28,6 +28,9 @@ export const exportDailyEmissionQuery = async ({
     })
     .andWhere('reportingPeriod.year = :year', { year })
     .andWhere('reportingPeriod.quarter = :quarter', { quarter })
+    .orderBy({
+      'dailyEmission.date': 'ASC',
+    })
     .getMany();
 };
 

--- a/src/sorbent-trap-functions/export-sorbent-trap-data.ts
+++ b/src/sorbent-trap-functions/export-sorbent-trap-data.ts
@@ -29,6 +29,10 @@ export const exportSorbentTrapQuery = ({
     })
     .andWhere('reportingPeriod.year = :year', { year: year })
     .andWhere('reportingPeriod.quarter = :quarter', { quarter: quarter })
+    .orderBy({
+      'sorbentTrap.beginDate': 'ASC',
+      'sorbentTrap.beginHour': 'ASC'
+    })
     .getMany();
 };
 

--- a/src/weekly-test-summary/weekly-test-summary.repository.spec.ts
+++ b/src/weekly-test-summary/weekly-test-summary.repository.spec.ts
@@ -32,6 +32,7 @@ describe('-- WeeklyTestSummaryRepository --', () => {
     queryBuilder.leftJoinAndSelect.mockReturnValue(queryBuilder);
     queryBuilder.where.mockReturnValue(queryBuilder);
     queryBuilder.andWhere.mockReturnValue(queryBuilder);
+    queryBuilder.orderBy.mockReturnValue(queryBuilder);
     queryBuilder.getMany.mockReturnValue('mockWeeklyTestSummary');
   });
 

--- a/src/weekly-test-summary/weekly-test-summary.repository.ts
+++ b/src/weekly-test-summary/weekly-test-summary.repository.ts
@@ -20,7 +20,11 @@ export class WeeklyTestSummaryRepository extends Repository<WeeklyTestSummary> {
         monitoringLocationIds: monitoringLocationIds,
       })
       .andWhere('r.year = :year ', { year })
-      .andWhere('r.quarter = :quarter ', { quarter });
+      .andWhere('r.quarter = :quarter ', { quarter })
+      .orderBy({
+        'wts.date': 'ASC',
+        'wts.hour': 'ASC'
+      });
 
     return query.getMany();
   }


### PR DESCRIPTION
Ticket
https://github.com/US-EPA-CAMD/easey-ui/issues/6194

Changes
Added the orderBy clause for Emissions Data.