### PR TITLE
Sprint 10 - query timeout

### DIFF
--- a/manifest-vars.beta.yml
+++ b/manifest-vars.beta.yml
@@ -2,3 +2,4 @@ instances: 2
 environment: beta
 host: api-easey-beta.app.cloud.gov
 apiHost: api.epa.gov/easey/beta
+statementTimeout: 300000

--- a/manifest-vars.perf.yml
+++ b/manifest-vars.perf.yml
@@ -2,3 +2,4 @@ instances: 2
 environment: performance
 host: api-easey-perf.app.cloud.gov
 apiHost: api.epa.gov/easey/perf
+statementTimeout: 300000

--- a/manifest-vars.prod.yml
+++ b/manifest-vars.prod.yml
@@ -2,3 +2,4 @@ instances: 2
 environment: production
 host: api-easey.app.cloud.gov
 apiHost: api.epa.gov/easey
+statementTimeout: 300000

--- a/manifest-vars.staging.yml
+++ b/manifest-vars.staging.yml
@@ -2,3 +2,4 @@ instances: 2
 environment: staging
 host: api-easey-stg.app.cloud.gov
 apiHost: api.epa.gov/easey/staging
+statementTimeout: 300000

--- a/manifest-vars.test.yml
+++ b/manifest-vars.test.yml
@@ -2,3 +2,4 @@ instances: 1
 environment: testing
 host: api-easey-tst.app.cloud.gov
 apiHost: api.epa.gov/easey/test
+statementTimeout: 300000

--- a/manifest-vars.yml
+++ b/manifest-vars.yml
@@ -11,3 +11,4 @@ description: Emissions management API endpoints for apportioned emissions data (
 environment: development
 apiHost: api.epa.gov/easey/dev
 dbSvc: camd-pg-db
+statementTimeout: 300000

--- a/manifest.yml
+++ b/manifest.yml
@@ -27,6 +27,7 @@ applications:
       EASEY_EMISSIONS_API_ENABLE_ROLE_GUARD_CHECKOUT: true
       EASEY_EMISSIONS_API_BULK_LOAD_MAX_POOL_SIZE: 100
       TZ: America/New_York
+      EASEY_DB_STATEMENT_TIMEOUT: ((statementTimeout))
     routes:
       - route: ((host))/((path))
     services:

--- a/src/config/app.config.ts
+++ b/src/config/app.config.ts
@@ -67,6 +67,7 @@ export default registerAs('app', () => ({
   reqSizeLimit: getConfigValue('EASEY_EMISSIONS_API_REQ_SIZE_LIMIT', '60mb'),
   // ENABLES DEBUG CONSOLE LOGS
   enableDebug: getConfigValueBoolean('EASEY_EMISSIONS_API_ENABLE_DEBUG'),
+  statementTimeout: getConfigValueNumber('EASEY_EMISSIONS_API_SUBMISSION_DAYS',300000),
   /**
    * Needs to be set in .env file for local development if `EASEY_EMISSIONS_API_ENABLE_AUTH_TOKEN` is false.
    * Format:

--- a/src/config/app.config.ts
+++ b/src/config/app.config.ts
@@ -67,7 +67,7 @@ export default registerAs('app', () => ({
   reqSizeLimit: getConfigValue('EASEY_EMISSIONS_API_REQ_SIZE_LIMIT', '60mb'),
   // ENABLES DEBUG CONSOLE LOGS
   enableDebug: getConfigValueBoolean('EASEY_EMISSIONS_API_ENABLE_DEBUG'),
-  statementTimeout: getConfigValueNumber('EASEY_EMISSIONS_API_SUBMISSION_DAYS',300000),
+  statementTimeout: getConfigValueNumber('EASEY_DB_STATEMENT_TIMEOUT',300000),
   /**
    * Needs to be set in .env file for local development if `EASEY_EMISSIONS_API_ENABLE_AUTH_TOKEN` is false.
    * Format:

--- a/src/config/typeorm.config.ts
+++ b/src/config/typeorm.config.ts
@@ -35,6 +35,9 @@ export class TypeOrmConfigService implements TypeOrmOptionsFactory {
       entities: [__dirname + '/../**/*.entity.{js,ts}'],
       synchronize: false,
       ssl: this.tlsOptions,
+      extra: {
+        statement_timeout: this.configService.get<number>('app.statementTimeout'),
+      },
     };
   }
 }


### PR DESCRIPTION
## Pull Request

Ticket 6350, Added a statement_timeout parameter (integer) to abort any statement in a query that takes more than the specified amount of time to run.