### PR TITLE
fix(6290): removed CheckCatalogModule

### DIFF
--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -6,7 +6,6 @@ import { TypeOrmModule } from '@nestjs/typeorm';
 import { dbConfig } from '@us-epa-camd/easey-common/config';
 import { LoggerModule } from '@us-epa-camd/easey-common/logger';
 import { CorsOptionsModule } from '@us-epa-camd/easey-common/cors-options';
-import { CheckCatalogModule } from '@us-epa-camd/easey-common/check-catalog';
 import { ConnectionModule } from '@us-epa-camd/easey-common/connection';
 import { DbLookupValidator } from '@us-epa-camd/easey-common/validators';
 
@@ -26,9 +25,6 @@ import { ApportionedEmissionsModule } from './apportioned-emissions/apportioned-
     TypeOrmModule.forRootAsync({
       useClass: TypeOrmConfigService,
     }),
-    CheckCatalogModule.register(
-      'camdecmpsmd.vw_emissions_api_check_catalog_results',
-    ),
     ConnectionModule,
     LoggerModule,
     CorsOptionsModule,


### PR DESCRIPTION
## Related Issues

- [#6290](https://github.com/US-EPA-CAMD/easey-ui/issues/6290)

## Main Changes

- Removed the `CheckCatalogModule`, which is unused and relies on an ECMPS-only view.