### PR TITLE
fix:exclude workspace api from swagger beta env

### DIFF
--- a/src/emissions-view-workspace/emissions-view.controller.ts
+++ b/src/emissions-view-workspace/emissions-view.controller.ts
@@ -17,6 +17,7 @@ import { EmissionsViewWorkspaceService } from './emissions-view.service';
 import { SetEmissionViewHeaderInterceptor } from '../inteceptors/set-emission-view-header.interceptor';
 import { IsViewCode } from '../pipes/is-view-code.pipe';
 import { LookupType } from '@us-epa-camd/easey-common/enums';
+import { ApiExcludeEndpointByEnv } from '../utils/swagger-decorator.const';
 
 @Controller()
 @ApiTags('Emissions Views')
@@ -71,6 +72,7 @@ export class EmissionsViewWorkspaceController {
     },
     LookupType.MonitorPlan,
   )
+  @ApiExcludeEndpointByEnv()
   getView(
     @Param('viewCode', IsViewCode) viewCode: string,
     @Req() req: Request,

--- a/src/emissions-view-workspace/emissions-view.controller.ts
+++ b/src/emissions-view-workspace/emissions-view.controller.ts
@@ -31,6 +31,7 @@ export class EmissionsViewWorkspaceController {
     description:
       'Retrieves a list of workspace Emissions data views that are available',
   })
+  @ApiExcludeEndpointByEnv()
   getAvailableViews(): Promise<EmissionsViewDTO[]> {
     return this.service.getAvailableViews();
   }

--- a/src/emissions-workspace/emissions.controller.ts
+++ b/src/emissions-workspace/emissions.controller.ts
@@ -30,6 +30,7 @@ import { EmissionsReviewSubmitDTO } from '../dto/emissions-review-submit.dto';
 import { ReviewAndSubmitMultipleParamsDTO } from '../dto/review-and-submit-multiple-params.dto';
 import { ReviewSubmitService } from './ReviewSubmit.service';
 import { LookupType } from '@us-epa-camd/easey-common/enums';
+import { ApiExcludeEndpointByEnv } from '../utils/swagger-decorator.const';
 
 @Controller()
 @ApiTags('Emissions')
@@ -78,6 +79,7 @@ export class EmissionsWorkspaceController {
     },
     LookupType.MonitorPlan,
   )
+  @ApiExcludeEndpointByEnv()
   @UseInterceptors(ClassSerializerInterceptor)
   async export(
     @Query() params: EmissionsParamsDTO,
@@ -114,6 +116,7 @@ export class EmissionsWorkspaceController {
     },
     LookupType.Location,
   )
+  @ApiExcludeEndpointByEnv()
   async import(@Body() payload: EmissionsImportDTO, @User() user: CurrentUser) {
     await this.checksService.runChecks(payload);
     return this.service.import(payload, user.userId);
@@ -152,6 +155,7 @@ export class EmissionsWorkspaceController {
     },
     LookupType.Facility,
   )
+  @ApiExcludeEndpointByEnv()
   async getEmissions(
     @Query() dto: ReviewAndSubmitMultipleParamsDTO,
   ): Promise<EmissionsReviewSubmitDTO[]> {

--- a/src/utils/swagger-decorator.const.ts
+++ b/src/utils/swagger-decorator.const.ts
@@ -2,9 +2,12 @@ import { applyDecorators } from '@nestjs/common';
 
 import {
   ApiBadRequestResponse,
+  ApiExcludeController,
+  ApiExcludeEndpoint,
   ApiNotFoundResponse,
   ApiQuery,
 } from '@nestjs/swagger';
+import { getConfigValue } from '@us-epa-camd/easey-common/utilities';
 
 export const BadRequestResponse = () =>
   ApiBadRequestResponse({
@@ -127,4 +130,15 @@ export function ApiLocationNameQuery() {
       explode: false,
     }),
   );
+}
+
+const env = getConfigValue('EASEY_EMISSIONS_API_ENV', 'local-dev');
+const disable = ['local-dev','development','testing'].includes(env) ? false : true;
+
+export function ApiExcludeControllerByEnv() {
+  return applyDecorators(ApiExcludeController(disable));
+}
+
+export function ApiExcludeEndpointByEnv() {
+  return applyDecorators(ApiExcludeEndpoint(disable));
 }


### PR DESCRIPTION
## Ticket
[Remove emissions-mgmt's workspace API from Swagger page](https://github.com/US-EPA-CAMD/easey-ui/issues/6466)

## Changes

- Create a decorator for exclude APIs end points from swagger page
- Apply created decorated in workspace APIs