### PR TITLE
fix/6530 Remove addDate Field from dailyBackstopData records

### DIFF
--- a/src/maps/daily-backstop.map.spec.ts
+++ b/src/maps/daily-backstop.map.spec.ts
@@ -19,7 +19,6 @@ describe('Daily Backstop Map Test', () => {
         unitId: mock.monitorLocation?.unit?.name ?? null,
         monitoringLocationId: mock.monitoringLocationId,
         userId: mock.userId,
-        addDate: mock.addDate?.toISOString() ?? null,
         updateDate: mock.updateDate?.toISOString() ?? null,
         reportingPeriodId: mock.reportingPeriodId,
         date: mock.date,

--- a/src/maps/daily-backstop.map.ts
+++ b/src/maps/daily-backstop.map.ts
@@ -20,7 +20,6 @@ export class DailyBackstopMap extends BaseMap<
             unitId,
             monitoringLocationId: entity.monitoringLocationId,
             userId: entity.userId,
-            addDate: entity.addDate?.toISOString() ?? null,
             updateDate: entity.updateDate?.toISOString() ?? null,
             reportingPeriodId: entity.reportingPeriodId,
             date: entity.date,

--- a/test/object-generators/daily-backstop.ts
+++ b/test/object-generators/daily-backstop.ts
@@ -24,7 +24,6 @@ export const genDailyBackstop = <RepoType>(
             dailyNoxExceedance: faker.datatype.number(),
             cumulativeOsNoxExceedance: faker.datatype.number(),
             userId: faker.datatype.string(),
-            addDate: faker.datatype.datetime(),
             updateDate: faker.datatype.datetime(),
             monitorLocation: config?.include?.includes('monitorLocation')
                 ? genMonitorLocation()[0]


### PR DESCRIPTION
Ticket
https://github.com/US-EPA-CAMD/easey-ui/issues/6530
Changes
Updated DailyBackstopMap  by removing addDate from return Promise<DailyBackstopDTO> object. 