### PR TITLE
fix/#6685 Inconsistent Filter Behavior in Evaluate and Submit Screen

### DIFF
--- a/src/dto/review-and-submit-multiple-params.dto.ts
+++ b/src/dto/review-and-submit-multiple-params.dto.ts
@@ -27,5 +27,6 @@ export class ReviewAndSubmitMultipleParamsDTO {
   })
   @ApiPropertyOptional()
   @Transform(({ value }) => value.split('|').map((item: string) => item.trim()))
+  @IsOptional()
   quarters: string[];
 }

--- a/src/emissions-workspace/ReviewSubmit.service.spec.ts
+++ b/src/emissions-workspace/ReviewSubmit.service.spec.ts
@@ -9,10 +9,22 @@ import { EmissionsReviewSubmitGlobalRepository } from './ReviewSubmitGlobal.repo
 
 const mockRepo = () => ({
   find: jest.fn().mockImplementation(args => {
-    if (args.where['monPlanId']) {
-      return [new EmissionsReviewSubmitDTO()];
+
+    const hasMonPlanId = !!args.where.monPlanId;
+    const hasPeriodAbbreviation = args.where.hasOwnProperty('periodAbbreviation');
+
+    if (hasMonPlanId) {
+      if (hasPeriodAbbreviation) {
+        return Promise.resolve([new EmissionsReviewSubmitDTO()]); // monPlanId with quarters -> 1 DTO
+      } else {
+        return Promise.resolve([]); // monPlanId without quarters -> 0 DTOs
+      }
     } else {
-      return [new EmissionsReviewSubmitDTO(), new EmissionsReviewSubmitDTO()];
+      if (hasPeriodAbbreviation) {
+        return Promise.resolve([new EmissionsReviewSubmitDTO(), new EmissionsReviewSubmitDTO()]); // orisCode with quarters -> 2 DTOs
+      } else {
+        return Promise.resolve([new EmissionsReviewSubmitDTO()]); // orisCode without quarters -> 1 DTO
+      }
     }
   }),
 });
@@ -63,6 +75,33 @@ describe('ReviewSubmitService', () => {
         [],
         ['MOCK'],
         ['2022 Q2'],
+      );
+      expect(result.length).toBe(1);
+    });
+
+    it('should handle orisCodes path correctly when quarters is null (no periodAbbreviation)', async () => {
+      const result = await service.getEmissionsRecords(
+        [3], 
+        [],  
+        null,
+      );
+      expect(result.length).toBe(1);
+    });
+
+    it('should handle monPlanIds path correctly when quarters is an array with an empty string (no periodAbbreviation)', async () => {
+      const result = await service.getEmissionsRecords(
+        [],      
+        ['MOCK'],
+        [""],    
+      );
+      expect(result.length).toBe(0);
+    });
+    
+    it('should handle orisCodes path correctly when quarters is an empty array (no periodAbbreviation)', async () => {
+      const result = await service.getEmissionsRecords(
+        [3],
+        [], 
+        [], 
       );
       expect(result.length).toBe(1);
     });

--- a/src/emissions-workspace/ReviewSubmit.service.spec.ts
+++ b/src/emissions-workspace/ReviewSubmit.service.spec.ts
@@ -15,17 +15,14 @@ const mockRepo = () => ({
 
     if (hasMonPlanId) {
       if (hasPeriodAbbreviation) {
-        return Promise.resolve([new EmissionsReviewSubmitDTO()]); // monPlanId with quarters -> 1 DTO
+        return Promise.resolve([]);
       } else {
-        return Promise.resolve([]); // monPlanId without quarters -> 0 DTOs
+        return Promise.resolve([new EmissionsReviewSubmitDTO()]);
       }
-    } else {
-      if (hasPeriodAbbreviation) {
-        return Promise.resolve([new EmissionsReviewSubmitDTO(), new EmissionsReviewSubmitDTO()]); // orisCode with quarters -> 2 DTOs
-      } else {
-        return Promise.resolve([new EmissionsReviewSubmitDTO()]); // orisCode without quarters -> 1 DTO
-      }
+    } else if (hasPeriodAbbreviation) {
+      return Promise.resolve([new EmissionsReviewSubmitDTO(), new EmissionsReviewSubmitDTO()]);
     }
+    return Promise.resolve([new EmissionsReviewSubmitDTO(), new EmissionsReviewSubmitDTO(), new EmissionsReviewSubmitDTO()]);
   }),
 });
 
@@ -66,44 +63,35 @@ describe('ReviewSubmitService', () => {
 
   describe('getEmissionsRecords', () => {
     it('should call the service function given list of orisCodes', async () => {
-      const result = await service.getEmissionsRecords([3], [], ['2022 Q2']);
-      expect(result.length).toBe(2);
+      const result = await service.getEmissionsRecords([3], [], []);
+      expect(result.length).toBe(3);
     });
 
-    it('should call the service function given list of monPlanIds', async () => {
+    it('should call the service function given list of monPlanIds, no quarters', async () => {
       const result = await service.getEmissionsRecords(
-        [],
+        [3],
         ['MOCK'],
-        ['2022 Q2'],
+        [],
       );
       expect(result.length).toBe(1);
     });
 
-    it('should handle orisCodes path correctly when quarters is null (no periodAbbreviation)', async () => {
+    it('should call the service function given list of quarters, no monPlanIds', async () => {
       const result = await service.getEmissionsRecords(
         [3], 
         [],  
-        null,
+        ["Q3"],
       );
-      expect(result.length).toBe(1);
+      expect(result.length).toBe(2);
     });
 
-    it('should handle monPlanIds path correctly when quarters is an array with an empty string (no periodAbbreviation)', async () => {
+    it('sshould call the service function given list of quarters and monPlanIds', async () => {
       const result = await service.getEmissionsRecords(
-        [],      
+        [3],      
         ['MOCK'],
-        [""],    
+        ["Q3"],    
       );
       expect(result.length).toBe(0);
-    });
-    
-    it('should handle orisCodes path correctly when quarters is an empty array (no periodAbbreviation)', async () => {
-      const result = await service.getEmissionsRecords(
-        [3],
-        [], 
-        [], 
-      );
-      expect(result.length).toBe(1);
     });
   });
 });

--- a/src/emissions-workspace/ReviewSubmit.service.ts
+++ b/src/emissions-workspace/ReviewSubmit.service.ts
@@ -29,31 +29,25 @@ export class ReviewSubmitService {
       repository = this.globalRepository;
     }
 
-    const cleanedQuarters = quarters?.filter(q => q && q.trim() !== '') ?? [];
-
-    const periodFilter = 
-    cleanedQuarters.length > 0
-        ? { periodAbbreviation: In(cleanedQuarters) }
-        : {};
+    const hasMonPlanIds = monPlanIds && monPlanIds.length > 0;
+    const hasQuarters = quarters && quarters.length > 0;
 
     try {
-      if (monPlanIds && monPlanIds.length > 0) {
+      if (hasMonPlanIds && hasQuarters) {
         return this.map.many(
-          await repository.find({
-            where: {
-              monPlanId: In(monPlanIds),
-              ...periodFilter,
-            },
-          }),
+          await repository.find({ where: { monPlanId: In(monPlanIds), periodAbbreviation: In(quarters), }, }),
+        );
+      } else if (hasMonPlanIds) {
+        return this.map.many(
+          await repository.find({ where: { monPlanId: In(monPlanIds), }, }),
+        );
+      } else if (hasQuarters) {
+        return this.map.many(
+          await repository.find({ where: { orisCode: In(orisCodes), periodAbbreviation: In(quarters), }, }),
         );
       }
       return this.map.many(
-        await repository.find({
-          where: { 
-            orisCode: In(orisCodes), 
-            ...periodFilter,
-          },
-        }),
+        await repository.find({ where: { orisCode: In(orisCodes), }}),
       );
     } catch (e) {
       throw new EaseyException(e, HttpStatus.INTERNAL_SERVER_ERROR);

--- a/src/emissions-workspace/ReviewSubmit.service.ts
+++ b/src/emissions-workspace/ReviewSubmit.service.ts
@@ -21,9 +21,6 @@ export class ReviewSubmitService {
     quarters: string[],
     isWorkspace: boolean = true,
   ): Promise<EmissionsReviewSubmitDTO[]> {
-    if (!quarters || quarters.length === 0) {
-      return [];
-    }
 
     let repository;
     if (isWorkspace) {
@@ -32,20 +29,30 @@ export class ReviewSubmitService {
       repository = this.globalRepository;
     }
 
+    const cleanedQuarters = quarters?.filter(q => q && q.trim() !== '') ?? [];
+
+    const periodFilter = 
+    cleanedQuarters.length > 0
+        ? { periodAbbreviation: In(cleanedQuarters) }
+        : {};
+
     try {
       if (monPlanIds && monPlanIds.length > 0) {
         return this.map.many(
           await repository.find({
             where: {
               monPlanId: In(monPlanIds),
-              periodAbbreviation: In(quarters),
+              ...periodFilter,
             },
           }),
         );
       }
       return this.map.many(
         await repository.find({
-          where: { orisCode: In(orisCodes), periodAbbreviation: In(quarters) },
+          where: { 
+            orisCode: In(orisCodes), 
+            ...periodFilter,
+          },
         }),
       );
     } catch (e) {


### PR DESCRIPTION
### **Related Ticket:**

- ticket [#6685](https://github.com/orgs/US-EPA-CAMD/projects/2/views/57?sliceBy%5Bvalue%5D=EvanSun220&pane=issue&itemId=108762833&issue=US-EPA-CAMD%7Ceasey-ui%7C6685)

### **Updates:**

- Update the logic in getEmissionsRecords from emissions-workspace/ReviewSubmitService, to allowed emissions records returned when no reporting period passed in.
- Updated related unit test.
