### PR TITLE
fix/#6656 Fix - Add A New importFromHisorical Endpoint on Emissions API

### DIFF
--- a/src/emissions-workspace/emissions.controller.spec.ts
+++ b/src/emissions-workspace/emissions.controller.spec.ts
@@ -21,7 +21,7 @@ import { DailyTestSummaryWorkspaceService } from '../daily-test-summary-workspac
 import { DerivedHourlyValueWorkspaceRepository } from '../derived-hourly-value-workspace/derived-hourly-value-workspace.repository';
 import { DerivedHourlyValueWorkspaceService } from '../derived-hourly-value-workspace/derived-hourly-value-workspace.service';
 import { EmissionsReviewSubmitDTO } from '../dto/emissions-review-submit.dto';
-import { EmissionsImportDTO } from '../dto/emissions.dto';
+import { EmissionsDTO, EmissionsImportDTO } from '../dto/emissions.dto';
 import { EmissionsParamsDTO } from '../dto/emissions.params.dto';
 import { ReviewAndSubmitMultipleParamsDTO } from '../dto/review-and-submit-multiple-params.dto';
 import { HourlyFuelFlowWorkspaceRepository } from '../hourly-fuel-flow-workspace/hourly-fuel-flow-workspace.repository';
@@ -92,8 +92,6 @@ import { ReviewSubmitService } from './ReviewSubmit.service';
 import { EmissionsReviewSubmitGlobalRepository } from './ReviewSubmitGlobal.repository';
 import { EaseyContentService } from '../emissions-easey-content/easey-content.service';
 import { SummaryValueDataCheckService } from '../summary-value-workspace/summary-value-data-check.service';
-import { SummaryValueWorkspaceModule } from '../summary-value-workspace/summary-value.module';
-import { CurrentUser }          from '@us-epa-camd/easey-common/interfaces';
 import { NotFoundException }    from '@nestjs/common';
 import { EmissionsService } from '../emissions/emissions.service';
 
@@ -230,36 +228,90 @@ describe('-- Emissions Controller --', () => {
   });
 
   describe('importFromHistorical', () => {
-    it('should call service.importFromHistoricalData and return a message', async () => {
-      const params = new EmissionsParamsDTO();
-      params.monitorPlanId = 'MP1';
-      params.year          = 2020;
-      params.quarter       = 2;
-      const user: CurrentUser = { userId: 'user1' } as any;
 
-      const expected = { message: 'Imported historical data' };
-  
-      jest
-        .spyOn(service, 'importFromHistoricalData')
-        .mockResolvedValue(expected);
-  
+    const params = new EmissionsParamsDTO();
+    params.monitorPlanId = 'TEST-MPID-001';
+    params.year = 2023;
+    params.quarter = 2;
+    params.reportedValuesOnly = true;
+
+    const user = {
+      userId: 'string',
+      sessionId: 'string',
+      expiration: 'string',
+      clientIp: 'string',
+      facilities: [],
+      roles: [],
+    };
+
+    const mockExportData: EmissionsImportDTO = {
+      orisCode: 123,
+      summaryValueData: [],
+      dailyEmissionData: [],
+      weeklyTestSummaryData: [],
+      dailyTestSummaryData: [],
+      hourlyOperatingData: [],
+      longTermFuelFlowData: [],
+      sorbentTrapData: [],
+      nsps4tSummaryData: [],
+      dailyBackstopData: [],
+      version: '',
+      year: 0,
+      quarter: 0
+    };
+
+    const mockImportSuccessMessage: { message: string } = {
+      message: 'Successfully imported emissions data.',
+    };
+
+    it('should successfully export data, run checks, and import historical data', async () => {
+      
+      jest.spyOn(service, 'export').mockResolvedValue(mockExportData);
+      jest.spyOn(emissionsChecksService, 'runChecks').mockResolvedValue(undefined);
+      jest.spyOn(service, 'import').mockResolvedValue(mockImportSuccessMessage);
+
       const result = await controller.importFromHistorical(params, user);
-  
-      expect(service.importFromHistoricalData).toHaveBeenCalledWith(params, user);
-      expect(result).toBe(expected);
+
+      expect(service.export).toHaveBeenCalledWith(params, params.reportedValuesOnly);
+      expect(emissionsChecksService.runChecks).toHaveBeenCalledWith(mockExportData);
+      expect(service.import).toHaveBeenCalledWith(mockExportData, user.userId);
+      expect(result).toEqual(mockImportSuccessMessage);
     });
-  
-    it('should bubble up NotFoundException from service', async () => {
-      const params = new EmissionsParamsDTO();
-      const user: CurrentUser = { userId: 'user1' } as any;
-  
-      jest
-        .spyOn(service, 'importFromHistoricalData')
-        .mockRejectedValue(new NotFoundException('no data'));
-  
+
+    it('should throw NotFoundException if historical data to export is not found', async () => {
+
+      jest.spyOn(service, 'export').mockResolvedValue(null);
+
+      const runChecksSpy = jest.spyOn(emissionsChecksService, 'runChecks');
+      const importSpy = jest.spyOn(service, 'import');
+
       await expect(
         controller.importFromHistorical(params, user),
-      ).rejects.toThrow(NotFoundException);
+      ).rejects.toThrow(
+        new NotFoundException(
+          'Import unsuccessful: no historical data found for this reporting period.',
+        ),
+      );
+
+      expect(runChecksSpy).not.toHaveBeenCalled();
+      expect(importSpy).not.toHaveBeenCalled();
+    });
+
+    it('should throw NotFoundException if historical data to export is an empty object', async () => {
+    
+      jest.spyOn(service, 'export').mockResolvedValue(new EmissionsDTO());
+      const runChecksSpy = jest.spyOn(emissionsChecksService, 'runChecks');
+      const importSpy = jest.spyOn(service, 'import');
+
+      await expect(
+        controller.importFromHistorical(params, user),
+      ).rejects.toThrow(
+        new NotFoundException(
+          'Import unsuccessful: no historical data found for this reporting period.',
+        ),
+      );
+      expect(runChecksSpy).not.toHaveBeenCalled();
+      expect(importSpy).not.toHaveBeenCalled();
     });
   });
   

--- a/src/emissions-workspace/emissions.controller.ts
+++ b/src/emissions-workspace/emissions.controller.ts
@@ -55,20 +55,13 @@ export class EmissionsWorkspaceController {
   })
   @RoleGuard(
     {
-      importLocationSources: [
-        'dailyEmissionData',
-        'weeklyTestSummaryData',
-        'summaryValueData',
-        'dailyTestSummaryData',
-        'hourlyOperatingData',
-        'longTermFuelFlowData',
-        'sorbentTrapData',
-        'nsps4tSummaryData',
-      ],
+      enforceCheckout: false,
+      queryParam: 'monitorPlanId',
+      enforceEvalSubmitCheck: false,
       permissionsForFacility: ['DSEM'],
       requiredRoles: ['Preparer', 'Submitter', 'Sponsor', 'Initial Authorizer'],
     },
-    LookupType.Location,
+    LookupType.MonitorPlan,
   )
   @AuditLog({
     label: 'Imported historical emissions data',
@@ -77,8 +70,16 @@ export class EmissionsWorkspaceController {
   async importFromHistorical(
     @Query() params: EmissionsParamsDTO,
     @User() user: CurrentUser,
-  ) { 
-    return this.service.importFromHistoricalData(params, user);
+  ) {
+    const exportData = await this.service.export(params, params.reportedValuesOnly);
+    if (!exportData || Object.keys(exportData).length === 0) {
+      throw new NotFoundException(
+        'Import unsuccessful: no historical data found for this reporting period.',
+      );
+    }
+    const emissionsImportDTOData = exportData as EmissionsImportDTO;
+    await this.checksService.runChecks(emissionsImportDTOData);
+    return this.service.import(emissionsImportDTOData, user.userId);
   }
 
   @Get('export')

--- a/src/emissions-workspace/emissions.service.spec.ts
+++ b/src/emissions-workspace/emissions.service.spec.ts
@@ -105,9 +105,6 @@ import { EmissionsWorkspaceService } from './emissions.service';
 import { EmissionsService } from '../emissions/emissions.service';
 import { EaseyContentService } from '../emissions-easey-content/easey-content.service';
 import { SummaryValueDataCheckService } from '../summary-value-workspace/summary-value-data-check.service';
-import { EmissionsParamsDTO } from '../dto/emissions.params.dto';
-import { CurrentUser }      from '@us-epa-camd/easey-common/interfaces';
-import { NotFoundException } from '@nestjs/common';
 
 describe('Emissions Workspace Service', () => {
   let dailyTestsummaryService: DailyTestSummaryWorkspaceService;
@@ -297,76 +294,6 @@ describe('Emissions Workspace Service', () => {
     await expect(
       emissionsService.delete({ monitorPlanId: '123', reportingPeriodId: 2 }),
     ).resolves.toEqual(undefined);
-  });
-
-  it('should successfully import from historical', async () => {
-    const workspace = emissionsService as any;
-    const params = {
-      monitorPlanId: 'MP1',
-      year: 2020,
-      quarter: 2,
-      reportedValuesOnly: false,
-    } as EmissionsParamsDTO;
-    const user: CurrentUser = { userId: 'user1' } as any;
-    const stubbedData = genEmissionsImportDto(1, {
-      include: ['longTermFuelFlowData'],
-    });
-
-    workspace.emissionsService.export.mockResolvedValueOnce(stubbedData);
-    workspace.checksService.runChecks.mockResolvedValueOnce([]);
-    const importSpy = jest.spyOn(workspace, 'import').mockResolvedValueOnce({ message: 'Imported Historical' });
-
-    const result = await emissionsService.importFromHistoricalData(params, user);
-
-    expect(workspace.emissionsService.export).toHaveBeenCalledWith(
-      params,
-      params.reportedValuesOnly,
-    );
-    expect(workspace.checksService.runChecks).toHaveBeenCalledWith(stubbedData);
-    expect(importSpy).toHaveBeenCalledWith(stubbedData, user.userId);
-    expect(result).toEqual({ message: 'Imported Historical' });
-  });
-
-  it('should propagate export errors', async () => {
-    const workspace = emissionsService as any;
-    const params = {
-      monitorPlanId: 'MP1',
-      year: 2020,
-      quarter: 2,
-      reportedValuesOnly: true,
-    } as EmissionsParamsDTO;
-    const user: CurrentUser = { userId: 'user1' } as any;
-
-    workspace.emissionsService.export.mockRejectedValue(
-      new Error('export failed'),
-    );
-
-    await expect(
-      emissionsService.importFromHistoricalData(params, user),
-    ).rejects.toThrow('export failed');
-  });
-
-  it('should propagate runChecks errors', async () => {
-    const workspace = emissionsService as any;
-    const params = {
-      monitorPlanId: 'MP1',
-      year: 2020,
-      quarter: 2,
-      reportedValuesOnly: false,
-    } as EmissionsParamsDTO;
-    const user: CurrentUser = { userId: 'user1' } as any;
-    const stubbedData = genEmissionsImportDto(1, {
-      include: ['longTermFuelFlowData'],
-    });
-
-    workspace.emissionsService.export.mockResolvedValue(stubbedData);
-    workspace.checksService.runChecks.mockRejectedValue(
-      new NotFoundException('no data'),
-    );
-
-    await expect(
-      emissionsService.importFromHistoricalData(params, user),
-    ).rejects.toThrow(NotFoundException);
   });
 
   it('should successfully export emissions data', async function() {

--- a/src/emissions-workspace/emissions.service.ts
+++ b/src/emissions-workspace/emissions.service.ts
@@ -77,18 +77,6 @@ export class EmissionsWorkspaceService {
     return this.repository.delete(criteria);
   }
 
-  async importFromHistoricalData(
-    params: EmissionsParamsDTO,
-    user: CurrentUser,
-  ) {
-    
-    const historicalData = await this.emissionsService.export(params, params.reportedValuesOnly);
-    const emissionsImportDTOData = historicalData as EmissionsImportDTO;
-    
-    await this.checksService.runChecks(emissionsImportDTOData);
-    return await this.import(emissionsImportDTOData, user.userId);
-  }
-
   async export(
     params: EmissionsParamsDTO,
     rptValuesOnly: boolean = false,


### PR DESCRIPTION
### **Related Ticket:**

- ticket [#6656](https://github.com/US-EPA-CAMD/easey-ui/issues/6656)  

### **Updates:**

- Updated the _import-historical_ end point in emissionsWorkspaceController.
- Removed the importFromHistorical method in emissionsWorkspaceService.
- Updated related unit tests.
