### PR TITLE
feat/#6656 Add A New importFromHistorical Endpoint on Emissions API

### DIFF
--- a/src/emissions-workspace/emissions.controller.spec.ts
+++ b/src/emissions-workspace/emissions.controller.spec.ts
@@ -93,7 +93,9 @@ import { EmissionsReviewSubmitGlobalRepository } from './ReviewSubmitGlobal.repo
 import { EaseyContentService } from '../emissions-easey-content/easey-content.service';
 import { SummaryValueDataCheckService } from '../summary-value-workspace/summary-value-data-check.service';
 import { SummaryValueWorkspaceModule } from '../summary-value-workspace/summary-value.module';
-import { NotFoundException } from '@nestjs/common';
+import { CurrentUser }          from '@us-epa-camd/easey-common/interfaces';
+import { NotFoundException }    from '@nestjs/common';
+import { EmissionsService } from '../emissions/emissions.service';
 
 describe('-- Emissions Controller --', () => {
   let controller: EmissionsWorkspaceController;
@@ -208,6 +210,12 @@ describe('-- Emissions Controller --', () => {
             '../daily-backstop-workspace/daily-backstop.service',
           ),
         },
+        {
+          provide: EmissionsService,
+          useValue: {
+            export: jest.fn(),
+          },
+        },
       ],
     }).compile();
 
@@ -222,90 +230,36 @@ describe('-- Emissions Controller --', () => {
   });
 
   describe('importFromHistorical', () => {
+    it('should call service.importFromHistoricalData and return a message', async () => {
+      const params = new EmissionsParamsDTO();
+      params.monitorPlanId = 'MP1';
+      params.year          = 2020;
+      params.quarter       = 2;
+      const user: CurrentUser = { userId: 'user1' } as any;
 
-    const params = new EmissionsParamsDTO();
-    params.monitorPlanId = 'TEST-MPID-001';
-    params.year = 2023;
-    params.quarter = 2;
-    params.reportedValuesOnly = true;
+      const expected = { message: 'Imported historical data' };
 
-    const user = {
-      userId: 'string',
-      sessionId: 'string',
-      expiration: 'string',
-      clientIp: 'string',
-      facilities: [],
-      roles: [],
-    };
-
-    const mockExportData: EmissionsImportDTO = {
-      orisCode: 123,
-      summaryValueData: [],
-      dailyEmissionData: [],
-      weeklyTestSummaryData: [],
-      dailyTestSummaryData: [],
-      hourlyOperatingData: [],
-      longTermFuelFlowData: [],
-      sorbentTrapData: [],
-      nsps4tSummaryData: [],
-      dailyBackstopData: [],
-      version: '',
-      year: 0,
-      quarter: 0
-    };
-
-    const mockImportSuccessMessage: { message: string } = {
-      message: 'Successfully imported emissions data.',
-    };
-
-    it('should successfully export data, run checks, and import historical data', async () => {
-
-      jest.spyOn(service, 'export').mockResolvedValue(mockExportData);
-      jest.spyOn(emissionsChecksService, 'runChecks').mockResolvedValue(undefined);
-      jest.spyOn(service, 'import').mockResolvedValue(mockImportSuccessMessage);
+      jest
+        .spyOn(service, 'importFromHistoricalData')
+        .mockResolvedValue(expected);
 
       const result = await controller.importFromHistorical(params, user);
 
-      expect(service.export).toHaveBeenCalledWith(params, params.reportedValuesOnly);
-      expect(emissionsChecksService.runChecks).toHaveBeenCalledWith(mockExportData);
-      expect(service.import).toHaveBeenCalledWith(mockExportData, user.userId);
-      expect(result).toEqual(mockImportSuccessMessage);
+      expect(service.importFromHistoricalData).toHaveBeenCalledWith(params, user);
+      expect(result).toBe(expected);
     });
 
-    it('should throw NotFoundException if historical data to export is not found', async () => {
+    it('should bubble up NotFoundException from service', async () => {
+      const params = new EmissionsParamsDTO();
+      const user: CurrentUser = { userId: 'user1' } as any;
 
-      jest.spyOn(service, 'export').mockResolvedValue(null);
-
-      const runChecksSpy = jest.spyOn(emissionsChecksService, 'runChecks');
-      const importSpy = jest.spyOn(service, 'import');
+      jest
+        .spyOn(service, 'importFromHistoricalData')
+        .mockRejectedValue(new NotFoundException('no data'));
 
       await expect(
         controller.importFromHistorical(params, user),
-      ).rejects.toThrow(
-        new NotFoundException(
-          'Import unsuccessful: no historical data found for this reporting period.',
-        ),
-      );
-
-      expect(runChecksSpy).not.toHaveBeenCalled();
-      expect(importSpy).not.toHaveBeenCalled();
-    });
-
-    it('should throw NotFoundException if historical data to export is an empty object', async () => {
-
-      jest.spyOn(service, 'export').mockResolvedValue(new EmissionsDTO());
-      const runChecksSpy = jest.spyOn(emissionsChecksService, 'runChecks');
-      const importSpy = jest.spyOn(service, 'import');
-
-      await expect(
-        controller.importFromHistorical(params, user),
-      ).rejects.toThrow(
-        new NotFoundException(
-          'Import unsuccessful: no historical data found for this reporting period.',
-        ),
-      );
-      expect(runChecksSpy).not.toHaveBeenCalled();
-      expect(importSpy).not.toHaveBeenCalled();
+      ).rejects.toThrow(NotFoundException);
     });
   });
 

--- a/src/emissions-workspace/emissions.controller.spec.ts
+++ b/src/emissions-workspace/emissions.controller.spec.ts
@@ -21,7 +21,7 @@ import { DailyTestSummaryWorkspaceService } from '../daily-test-summary-workspac
 import { DerivedHourlyValueWorkspaceRepository } from '../derived-hourly-value-workspace/derived-hourly-value-workspace.repository';
 import { DerivedHourlyValueWorkspaceService } from '../derived-hourly-value-workspace/derived-hourly-value-workspace.service';
 import { EmissionsReviewSubmitDTO } from '../dto/emissions-review-submit.dto';
-import { EmissionsImportDTO } from '../dto/emissions.dto';
+import { EmissionsDTO, EmissionsImportDTO } from '../dto/emissions.dto';
 import { EmissionsParamsDTO } from '../dto/emissions.params.dto';
 import { ReviewAndSubmitMultipleParamsDTO } from '../dto/review-and-submit-multiple-params.dto';
 import { HourlyFuelFlowWorkspaceRepository } from '../hourly-fuel-flow-workspace/hourly-fuel-flow-workspace.repository';
@@ -93,6 +93,7 @@ import { EmissionsReviewSubmitGlobalRepository } from './ReviewSubmitGlobal.repo
 import { EaseyContentService } from '../emissions-easey-content/easey-content.service';
 import { SummaryValueDataCheckService } from '../summary-value-workspace/summary-value-data-check.service';
 import { SummaryValueWorkspaceModule } from '../summary-value-workspace/summary-value.module';
+import { NotFoundException } from '@nestjs/common';
 
 describe('-- Emissions Controller --', () => {
   let controller: EmissionsWorkspaceController;
@@ -218,6 +219,94 @@ describe('-- Emissions Controller --', () => {
 
   afterEach(() => {
     jest.resetAllMocks();
+  });
+
+  describe('importFromHistorical', () => {
+
+    const params = new EmissionsParamsDTO();
+    params.monitorPlanId = 'TEST-MPID-001';
+    params.year = 2023;
+    params.quarter = 2;
+    params.reportedValuesOnly = true;
+
+    const user = {
+      userId: 'string',
+      sessionId: 'string',
+      expiration: 'string',
+      clientIp: 'string',
+      facilities: [],
+      roles: [],
+    };
+
+    const mockExportData: EmissionsImportDTO = {
+      orisCode: 123,
+      summaryValueData: [],
+      dailyEmissionData: [],
+      weeklyTestSummaryData: [],
+      dailyTestSummaryData: [],
+      hourlyOperatingData: [],
+      longTermFuelFlowData: [],
+      sorbentTrapData: [],
+      nsps4tSummaryData: [],
+      dailyBackstopData: [],
+      version: '',
+      year: 0,
+      quarter: 0
+    };
+
+    const mockImportSuccessMessage: { message: string } = {
+      message: 'Successfully imported emissions data.',
+    };
+
+    it('should successfully export data, run checks, and import historical data', async () => {
+
+      jest.spyOn(service, 'export').mockResolvedValue(mockExportData);
+      jest.spyOn(emissionsChecksService, 'runChecks').mockResolvedValue(undefined);
+      jest.spyOn(service, 'import').mockResolvedValue(mockImportSuccessMessage);
+
+      const result = await controller.importFromHistorical(params, user);
+
+      expect(service.export).toHaveBeenCalledWith(params, params.reportedValuesOnly);
+      expect(emissionsChecksService.runChecks).toHaveBeenCalledWith(mockExportData);
+      expect(service.import).toHaveBeenCalledWith(mockExportData, user.userId);
+      expect(result).toEqual(mockImportSuccessMessage);
+    });
+
+    it('should throw NotFoundException if historical data to export is not found', async () => {
+
+      jest.spyOn(service, 'export').mockResolvedValue(null);
+
+      const runChecksSpy = jest.spyOn(emissionsChecksService, 'runChecks');
+      const importSpy = jest.spyOn(service, 'import');
+
+      await expect(
+        controller.importFromHistorical(params, user),
+      ).rejects.toThrow(
+        new NotFoundException(
+          'Import unsuccessful: no historical data found for this reporting period.',
+        ),
+      );
+
+      expect(runChecksSpy).not.toHaveBeenCalled();
+      expect(importSpy).not.toHaveBeenCalled();
+    });
+
+    it('should throw NotFoundException if historical data to export is an empty object', async () => {
+
+      jest.spyOn(service, 'export').mockResolvedValue(new EmissionsDTO());
+      const runChecksSpy = jest.spyOn(emissionsChecksService, 'runChecks');
+      const importSpy = jest.spyOn(service, 'import');
+
+      await expect(
+        controller.importFromHistorical(params, user),
+      ).rejects.toThrow(
+        new NotFoundException(
+          'Import unsuccessful: no historical data found for this reporting period.',
+        ),
+      );
+      expect(runChecksSpy).not.toHaveBeenCalled();
+      expect(importSpy).not.toHaveBeenCalled();
+    });
   });
 
   describe('* export', () => {

--- a/src/emissions-workspace/emissions.controller.ts
+++ b/src/emissions-workspace/emissions.controller.ts
@@ -44,6 +44,44 @@ export class EmissionsWorkspaceController {
     private readonly checksService: EmissionsChecksService,
   ) { }
 
+  @Post('import-historical')
+  @ApiBearerAuth('Token')
+  @ApiOperation({
+    summary: 'Imports historical emissions data directly into the workspace.',
+  })
+  @ApiOkResponse({
+    type: EmissionsDTO,
+    description: 'Successfully imported historical emissions data.',
+  })
+  @RoleGuard(
+    {
+      enforceCheckout: false,
+      queryParam: 'monitorPlanId',
+      enforceEvalSubmitCheck: false,
+      permissionsForFacility: ['DSEM'],
+      requiredRoles: ['Preparer', 'Submitter', 'Sponsor', 'Initial Authorizer'],
+    },
+    LookupType.MonitorPlan,
+  )
+  @AuditLog({
+    label: 'Imported historical emissions data',
+    requestQueryOutFields: ['monitorPlanId', 'year', 'quarter']
+  })
+  async importFromHistorical(
+    @Query() params: EmissionsParamsDTO,
+    @User() user: CurrentUser,
+  ) { 
+    const exportData = await this.service.export(params, params.reportedValuesOnly);
+    if (!exportData || Object.keys(exportData).length === 0) {
+      throw new NotFoundException(
+        'Import unsuccessful: no historical data found for this reporting period.',
+      );
+    }
+    const emissionsImportDTOData = exportData as EmissionsImportDTO;
+    await this.checksService.runChecks(emissionsImportDTOData);
+    return this.service.import(emissionsImportDTOData, user.userId);
+  }
+
   @Get('export')
   @ApiOperation({
     summary:

--- a/src/emissions-workspace/emissions.controller.ts
+++ b/src/emissions-workspace/emissions.controller.ts
@@ -55,9 +55,8 @@ export class EmissionsWorkspaceController {
   })
   @RoleGuard(
     {
-      enforceCheckout: false,
       queryParam: 'monitorPlanId',
-      enforceEvalSubmitCheck: false,
+      enforceCheckout: true,
       permissionsForFacility: ['DSEM'],
       requiredRoles: ['Preparer', 'Submitter', 'Sponsor', 'Initial Authorizer'],
     },
@@ -67,19 +66,12 @@ export class EmissionsWorkspaceController {
     label: 'Imported historical emissions data',
     requestQueryOutFields: ['monitorPlanId', 'year', 'quarter']
   })
+  @UseInterceptors(ClassSerializerInterceptor)
   async importFromHistorical(
     @Query() params: EmissionsParamsDTO,
     @User() user: CurrentUser,
   ) { 
-    const exportData = await this.service.export(params, params.reportedValuesOnly);
-    if (!exportData || Object.keys(exportData).length === 0) {
-      throw new NotFoundException(
-        'Import unsuccessful: no historical data found for this reporting period.',
-      );
-    }
-    const emissionsImportDTOData = exportData as EmissionsImportDTO;
-    await this.checksService.runChecks(emissionsImportDTOData);
-    return this.service.import(emissionsImportDTOData, user.userId);
+    return this.service.importFromHistoricalData(params, user);
   }
 
   @Get('export')

--- a/src/emissions-workspace/emissions.module.ts
+++ b/src/emissions-workspace/emissions.module.ts
@@ -1,5 +1,5 @@
 import { LoggerModule } from '@us-epa-camd/easey-common/logger';
-import { Module } from '@nestjs/common';
+import { Module, forwardRef } from '@nestjs/common';
 import { HttpModule } from '@nestjs/axios';
 import { TypeOrmModule } from '@nestjs/typeorm';
 
@@ -48,6 +48,7 @@ import { EmissionsReviewSubmitGlobalRepository } from './ReviewSubmitGlobal.repo
 import { CodeChecksModule } from '../code-checks/code-checks.module';
 import { CodeChecksService } from '../code-checks/code-checks.service';
 import { EaseyContentModule } from '../emissions-easey-content/easey-content.module';
+import { EmissionsModule } from '../emissions/emissions.module';
 
 @Module({
   imports: [
@@ -80,6 +81,7 @@ import { EaseyContentModule } from '../emissions-easey-content/easey-content.mod
     Nsps4tSummaryWorkspaceModule,
     Nsps4tAnnualWorkspaceModule,
     Nsps4tCompliancePeriodWorkspaceModule,
+    forwardRef(() => EmissionsModule),
   ],
   controllers: [EmissionsWorkspaceController],
   providers: [

--- a/src/emissions-workspace/emissions.service.spec.ts
+++ b/src/emissions-workspace/emissions.service.spec.ts
@@ -104,6 +104,10 @@ import { EmissionsWorkspaceRepository } from './emissions.repository';
 import { EmissionsWorkspaceService } from './emissions.service';
 import { EaseyContentService } from '../emissions-easey-content/easey-content.service';
 import { SummaryValueDataCheckService } from '../summary-value-workspace/summary-value-data-check.service';
+import { EmissionsService } from '../emissions/emissions.service';
+import { EmissionsParamsDTO } from '../dto/emissions.params.dto';
+import { CurrentUser }      from '@us-epa-camd/easey-common/interfaces';
+import { NotFoundException } from '@nestjs/common';
 
 describe('Emissions Workspace Service', () => {
   let dailyTestsummaryService: DailyTestSummaryWorkspaceService;
@@ -258,7 +262,20 @@ describe('Emissions Workspace Service', () => {
               version : '1.0.0'
             }),
           })
-        }
+        },
+        {
+          provide: EmissionsService,
+          useValue: {
+            export: jest.fn(),
+          },
+        },
+        {
+          provide: EmissionsChecksService,
+          useValue: { 
+            runChecks: jest.fn(), 
+            invalidFormulasCheck: jest.fn(),
+          },
+        },
       ],
     }).compile();
 
@@ -280,6 +297,76 @@ describe('Emissions Workspace Service', () => {
     await expect(
       emissionsService.delete({ monitorPlanId: '123', reportingPeriodId: 2 }),
     ).resolves.toEqual(undefined);
+  });
+
+  it('should successfully import from historical', async () => {
+    const workspace = emissionsService as any;
+    const params = {
+      monitorPlanId: 'MP1',
+      year: 2020,
+      quarter: 2,
+      reportedValuesOnly: false,
+    } as EmissionsParamsDTO;
+    const user: CurrentUser = { userId: 'user1' } as any;
+    const stubbedData = genEmissionsImportDto(1, {
+      include: ['longTermFuelFlowData'],
+    });
+
+    workspace.emissionsService.export.mockResolvedValueOnce(stubbedData);
+    workspace.checksService.runChecks.mockResolvedValueOnce([]);
+    const importSpy = jest.spyOn(workspace, 'import').mockResolvedValueOnce({ message: 'Imported Historical' });
+
+    const result = await emissionsService.importFromHistoricalData(params, user);
+
+    expect(workspace.emissionsService.export).toHaveBeenCalledWith(
+      params,
+      params.reportedValuesOnly,
+    );
+    expect(workspace.checksService.runChecks).toHaveBeenCalledWith(stubbedData);
+    expect(importSpy).toHaveBeenCalledWith(stubbedData, user.userId);
+    expect(result).toEqual({ message: 'Imported Historical' });
+  });
+
+  it('should propagate export errors', async () => {
+    const workspace = emissionsService as any;
+    const params = {
+      monitorPlanId: 'MP1',
+      year: 2020,
+      quarter: 2,
+      reportedValuesOnly: true,
+    } as EmissionsParamsDTO;
+    const user: CurrentUser = { userId: 'user1' } as any;
+
+    workspace.emissionsService.export.mockRejectedValue(
+      new Error('export failed'),
+    );
+
+    await expect(
+      emissionsService.importFromHistoricalData(params, user),
+    ).rejects.toThrow('export failed');
+  });
+
+  it('should propagate runChecks errors', async () => {
+    const workspace = emissionsService as any;
+    const params = {
+      monitorPlanId: 'MP1',
+      year: 2020,
+      quarter: 2,
+      reportedValuesOnly: false,
+    } as EmissionsParamsDTO;
+    const user: CurrentUser = { userId: 'user1' } as any;
+    const stubbedData = genEmissionsImportDto(1, {
+      include: ['longTermFuelFlowData'],
+    });
+
+    workspace.emissionsService.export.mockResolvedValue(stubbedData);
+    workspace.checksService.runChecks.mockRejectedValue(
+      new NotFoundException('no data'),
+    );
+
+    await expect(
+      emissionsService.importFromHistoricalData(params, user),
+    ).rejects.toThrow(NotFoundException);
   });
 
   it('should successfully export emissions data', async function() {

--- a/src/emissions-workspace/emissions.service.ts
+++ b/src/emissions-workspace/emissions.service.ts
@@ -32,6 +32,8 @@ import { WeeklyTestSummaryWorkspaceService } from '../weekly-test-summary-worksp
 import { EmissionsChecksService } from './emissions-checks.service';
 import { EmissionsWorkspaceRepository } from './emissions.repository';
 import { EaseyContentService} from '../emissions-easey-content/easey-content.service';
+import { EmissionsService } from '../emissions/emissions.service';
+import { CurrentUser } from '@us-epa-camd/easey-common/interfaces';
 
 type Dictionary = { [index: string]: string }
 
@@ -49,6 +51,7 @@ export type ImportIdentifiers = {
 @Injectable()
 export class EmissionsWorkspaceService {
   constructor(
+    private readonly emissionsService: EmissionsService,
     private readonly entityManager: EntityManager,
     private readonly map: EmissionsMap,
     private readonly checksService: EmissionsChecksService,
@@ -72,6 +75,21 @@ export class EmissionsWorkspaceService {
 
   async delete(criteria: DeleteCriteria): Promise<DeleteResult> {
     return this.repository.delete(criteria);
+  }
+
+  async importFromHistoricalData(
+    params: EmissionsParamsDTO,
+    user: CurrentUser,
+  ) {
+    const historicalData = await this.emissionsService.export(params, params.reportedValuesOnly);
+    if (!historicalData || Object.keys(historicalData).length === 0) {
+      throw new NotFoundException(
+        'Import unsuccessful: no historical data found for this reporting period.',
+      );
+    }
+    const emissionsImportDTOData = historicalData as EmissionsImportDTO;
+    await this.checksService.runChecks(emissionsImportDTOData);
+    return await this.import(emissionsImportDTOData, user.userId);
   }
 
   async export(

--- a/src/emissions/emissions.module.ts
+++ b/src/emissions/emissions.module.ts
@@ -1,4 +1,4 @@
-import { Module } from '@nestjs/common';
+import { Module, forwardRef } from '@nestjs/common';
 import { TypeOrmModule } from '@nestjs/typeorm';
 
 import { DailyBackstopModule } from '../daily-backstop/daily-backstop.module';
@@ -44,12 +44,12 @@ import { EaseyContentModule } from '../emissions-easey-content/easey-content.mod
     SummaryValueModule,
     LongTermFuelFlowModule,
     DailyBackstopModule,
-    EmissionsWorkspaceModule,
     Nsps4tAnnualModule,
     Nsps4tCompliancePeriodModule,
     Nsps4tSummaryModule,
     SamplingTrainModule,
     SorbentTrapModule,
+    forwardRef(() => EmissionsWorkspaceModule),
   ],
   controllers: [EmissionsController],
   providers: [


### PR DESCRIPTION
### **Related Ticket:**

- ticket [#6656](https://github.com/US-EPA-CAMD/easey-ui/issues/6656)

### **Updates:**

- Added import-historical endpoint for emissionsWorkspaceController
- Updated related services and modules
- Added related tests

