### PR TITLE
remove year from houly/unit

### DIFF
--- a/src/constants/field-mappings.ts
+++ b/src/constants/field-mappings.ts
@@ -130,7 +130,6 @@ hourly.push(
   ...commonCharacteristics,
   {...propertyMetadata.unit_id.fieldLabels},
   { ...propertyMetadata.associatedStacks.fieldLabels },
-  {...propertyMetadata.year.fieldLabels},
   ...hourlyCharacteristics,
   { ...propertyMetadata.grossLoadHourly.fieldLabels },
   { ...propertyMetadata.steamLoadHourly.fieldLabels },


### PR DESCRIPTION
## Ticket
[Bug: CAMPD emissions data download columns downloaded are not all correct](https://github.com/US-EPA-CAMD/easey-ui/issues/6751)

## Changes

- Remove year from houly/unit