### PR TITLE
Update anyOf Location Lookup Logic + Tests [#6932]

### DIFF
--- a/src/daily-emission-workspace/daily-emission-workspace.service.spec.ts
+++ b/src/daily-emission-workspace/daily-emission-workspace.service.spec.ts
@@ -1,4 +1,5 @@
 import { faker } from '@faker-js/faker';
+import { BadRequestException } from '@nestjs/common';
 import { ConfigService } from '@nestjs/config';
 import { Test, TestingModule } from '@nestjs/testing';
 import { BulkLoadService } from '@us-epa-camd/easey-common/bulk-load';
@@ -17,6 +18,7 @@ import { DailyEmissionMap } from '../maps/daily-emission.map';
 import { DailyFuelMap } from '../maps/daily-fuel.map';
 import { DailyEmissionWorkspaceRepository } from './daily-emission-workspace.repository';
 import { DailyEmissionWorkspaceService } from './daily-emission-workspace.service';
+import { ImportIdentifiers } from '../emissions-workspace/emissions.service';
 
 describe('DailyEmissionWorkspaceService', () => {
   let map: DailyEmissionMap;
@@ -118,6 +120,127 @@ describe('DailyEmissionWorkspaceService', () => {
 
       expect(result.length).toEqual(1);
       expect(result[0].dailyFuelData.length).toEqual(1);
+       });
+  });
+
+  // Test location lookup with anyOf schema compliance
+  describe('Location Lookup - anyOf Schema Compliance', () => {
+    beforeEach(() => {
+      // Mock bulkLoadService to prevent database connections in TT6932 tests
+      jest.spyOn(bulkLoadService, 'startBulkLoader').mockResolvedValue({
+        writeObject: jest.fn(),
+        complete: jest.fn().mockResolvedValue(undefined),
+      } as any);
+    });
+    const mockLocations = [
+      { id: 'LOC1', unit: { name: '3' }, stackPipe: null },
+      { id: 'LOC2', unit: null, stackPipe: { name: 'CS1' } },
+      { id: 'LOC3', unit: { name: '4' }, stackPipe: { name: 'CS2' } },
+    ];
+
+    const mockEmissionsImport = {
+      dailyEmissionData: []
+    };
+
+    it('should find location with unitId only', async () => {
+      const dailyEmissionData = [
+        { unitId: '3', stackPipeId: null, parameterCode: 'CO2' }
+      ];
+
+      mockEmissionsImport.dailyEmissionData = dailyEmissionData;
+
+      // Should not throw error for valid unitId-only location
+      await expect(service.import(
+        mockEmissionsImport as EmissionsImportDTO,
+        mockLocations as any,
+        1,
+        { userid: 'testUser' } as unknown as ImportIdentifiers, // identifiers
+        '2023-01-01T00:00:00Z'
+      )).resolves.not.toThrow();
+
+      //To verify the location was found and assigned
+      expect(dailyEmissionData[0]['locationId']).toBe('LOC1');
+    });
+
+    it('should find location with stackPipeId only', async () => {
+      const dailyEmissionData = [
+        { unitId: null, stackPipeId: 'CS1', parameterCode: 'CO2' }
+      ];
+
+      mockEmissionsImport.dailyEmissionData = dailyEmissionData;
+
+      // Should not throw error for valid stackPipeId-only location
+      await expect(service.import(
+        mockEmissionsImport as EmissionsImportDTO,
+        mockLocations as any,
+      1,
+        { userId: 'testUser' } as unknown as ImportIdentifiers, // identifiers
+        '2023-01-01T00:00:00Z'
+      )).resolves.not.toThrow();
+
+      // Verify the location was found and assigned (TT6932 fix working)
+      expect(dailyEmissionData[0]['locationId']).toBe('LOC2');
+      });
+
+    it('should find location with both unitId and stackPipeId', async () => {
+      const dailyEmissionData = [
+        { unitId: '4', stackPipeId: 'CS2', parameterCode: 'CO2' }
+      ];
+
+      mockEmissionsImport.dailyEmissionData = dailyEmissionData;
+
+      // Should not throw error for valid both identifiers location
+      await expect(service.import(
+        mockEmissionsImport as EmissionsImportDTO,
+        mockLocations as any,
+        1,
+        { userid: 'testUser' } as unknown as ImportIdentifiers, // identifiers
+        '2023-01-01T00:00:00Z'
+      )).resolves.not.toThrow();
+
+      // Verify the location was found and assigned
+      expect(dailyEmissionData[0]['locationId']).toBe('LOC3');
+    });
+
+    it('should throw error when no location found', async () => {
+      const dailyEmissionData = [
+        { unitId: 'NOMATCH', stackPipeId: null, parameterCode: 'CO2' }
+      ];
+
+      mockEmissionsImport.dailyEmissionData = dailyEmissionData;
+
+      await expect(
+        service.import(
+          mockEmissionsImport as EmissionsImportDTO,
+          mockLocations as any,
+          1,
+        { userid: 'testUser' } as unknown as ImportIdentifiers, // identifiers
+        '2023-01-01T00:00:00Z'
+        )
+      ).rejects.toThrow(BadRequestException);
+    });
+
+    it('should throw error when multiple locations found', async () => {
+      const ambiguousLocations = [
+        { id: 'LOC1', unit: { name: '3' }, stackPipe: null },
+        { id: 'LOC4', unit: { name: '3' }, stackPipe: null },
+      ];
+
+      const dailyEmissionData = [
+        { unitId: '3', stackPipeId: null, parameterCode: 'CO2' }
+      ];
+
+      mockEmissionsImport.dailyEmissionData = dailyEmissionData;
+
+      await expect(
+        service.import(
+          mockEmissionsImport as EmissionsImportDTO,
+          ambiguousLocations as any,
+          1,
+        { userid: 'testUser' } as unknown as ImportIdentifiers, // identifiers
+        '2023-01-01T00:00:00Z'
+        )
+      ).rejects.toThrow(BadRequestException);
     });
   });
 });

--- a/src/daily-emission-workspace/daily-emission-workspace.service.ts
+++ b/src/daily-emission-workspace/daily-emission-workspace.service.ts
@@ -1,4 +1,4 @@
-import { Injectable } from '@nestjs/common';
+import { BadRequestException, Injectable } from '@nestjs/common';
 import { BulkLoadService } from '@us-epa-camd/easey-common/bulk-load';
 import { randomUUID } from 'crypto';
 import { DeleteResult, EntityManager } from 'typeorm';
@@ -94,12 +94,30 @@ export class DailyEmissionWorkspaceService {
     );
 
     for (const dailyEmissionDatum of emissionsImport.dailyEmissionData) {
-      const monitoringLocationId = monitoringLocations.filter(location => {
-        return (
-          location.unit?.name === dailyEmissionDatum.unitId ||
-          location.stackPipe?.name === dailyEmissionDatum.stackPipeId
+      // Handle anyOf schema - either unitId OR stackPipeId (or both)
+      const matchingLocations = monitoringLocations.filter(location => {
+        if (dailyEmissionDatum.unitId && dailyEmissionDatum.stackPipeId) {
+          return location.unit?.name === dailyEmissionDatum.unitId &&
+                 location.stackPipe?.name === dailyEmissionDatum.stackPipeId;
+        } else if (dailyEmissionDatum.unitId) {
+          return location.unit?.name === dailyEmissionDatum.unitId;
+        } else if (dailyEmissionDatum.stackPipeId) {
+          return location.stackPipe?.name === dailyEmissionDatum.stackPipeId;
+        }
+        return false;
+      });
+
+      if (matchingLocations.length === 0) {
+        throw new BadRequestException(
+          `No location found for unitId: ${dailyEmissionDatum.unitId}, stackPipeId: ${dailyEmissionDatum.stackPipeId}`
         );
-      })[0].id;
+      }
+      if (matchingLocations.length > 1) {
+        throw new BadRequestException(
+          'Multiple locations found - unable to determine unique location'
+        );
+      }
+      const monitoringLocationId = matchingLocations[0].id;
 
       const uid = randomUUID();
       dailyEmissionDatum['id'] = uid;

--- a/src/daily-test-summary-workspace/daily-test-summary.service.spec.ts
+++ b/src/daily-test-summary-workspace/daily-test-summary.service.spec.ts
@@ -1,5 +1,6 @@
 import { Test, TestingModule } from '@nestjs/testing';
 import { faker } from '@faker-js/faker';
+import { BadRequestException } from '@nestjs/common';
 import { DailyCalibrationMap } from '../maps/daily-calibration.map';
 import { DailyTestSummaryWorkspaceService } from './daily-test-summary.service';
 import { DailyTestSummaryWorkspaceRepository } from './daily-test-summary.repository';
@@ -112,24 +113,193 @@ describe('Daily Summary Workspace Service', () => {
 
   it('should successfully import', async function() {
     const emissionsDto = new EmissionsImportDTO();
-    emissionsDto.dailyTestSummaryData = [
-      new DailyTestSummaryImportDTO(),
-      new DailyTestSummaryImportDTO(),
-      new DailyTestSummaryImportDTO(),
-    ];
+    const dto1 = new DailyTestSummaryImportDTO();
+    dto1.unitId = '3';
+    dto1.stackPipeId = null;
+    const dto2 = new DailyTestSummaryImportDTO();
+    dto2.unitId = null;
+    dto2.stackPipeId = 'CS1';
+    const dto3 = new DailyTestSummaryImportDTO();
+    dto3.unitId = '4';
+    dto3.stackPipeId = 'CS2';
+    emissionsDto.dailyTestSummaryData = [dto1, dto2, dto3];
 
     const identifiers = { locations: {}, userId: '' };
+    const mockLocations = [
+      { id: 'LOC1', unit: { name: '3' }, stackPipe: null },
+      { id: 'LOC2', unit: null, stackPipe: { name: 'CS1' } },
+      { id: 'LOC3', unit: { name: '4' }, stackPipe: { name: 'CS2' } },
+    ];
     const monitoringLocationId = faker.datatype.string();
     identifiers.locations[monitoringLocationId] = { components: {}, monitorFormulas: {}, monitoringSystems: {} };
 
     await dailyTestSummaryService.import(
       emissionsDto,
-      [new MonitorLocation()],
+      mockLocations,
       1,
       identifiers,
       new Date().toISOString(),
     );
 
     expect(writeObjectMock).toHaveBeenCalledTimes(3);
+    });
+
+  // Location lookup with anyOf schema compliance
+  describe('Location Lookup - anyOf Schema Compliance', () => {
+    const mockLocations = [
+      {
+        id: 'LOC1',
+        unit: { name: '3' },
+        stackPipe: null
+      },
+      {
+        id: 'LOC2',
+        unit: null,
+        stackPipe: { name: 'CS1' }
+      },
+      {
+        id: 'LOC3',
+        unit: { name: '4' },
+        stackPipe: { name: 'CS2' }
+      },
+    ];
+
+    const mockEmissionsImport = {
+      dailyTestSummaryData: []
+    };
+
+    it('should find location with unitId only', async () => {
+      const dailyTestSummaryData = [
+        { unitId: '3', stackPipeId: null, testTypeCode: 'RATA' }
+      ];
+
+      mockEmissionsImport.dailyTestSummaryData = dailyTestSummaryData;
+
+      const identifiers = {
+        userId: 'testUser',
+        locations: {
+          'LOC1': {
+            components: {},
+            monitorFormulas: {},
+            monitoringSystems: {}
+          }
+        }
+      };
+      // Should not throw error for valid unitId-only location
+      await expect(dailyTestSummaryService.import(
+        mockEmissionsImport as EmissionsImportDTO,
+        mockLocations as any,
+        1, // reportingPeriodId
+        identifiers as any, // identifiers
+        '2023-01-01T00:00:00Z' // currentTime
+      )).resolves.not.toThrow();
+    });
+
+    it('should find location with stackPipeId only', async () => {
+      const dailyTestSummaryData = [
+        { unitId: null, stackPipeId: 'CS1', testTypeCode: 'RATA' }
+      ];
+
+      mockEmissionsImport.dailyTestSummaryData = dailyTestSummaryData;
+
+      const identifiers = {
+        userId: 'testUser',
+        locations: {
+          'LOC2': {
+            components: {},
+            monitorFormulas: {},
+            monitoringSystems: {}
+          }
+        }
+      };
+
+      // Should not throw error for valid stackPipeId-only location
+      await expect(dailyTestSummaryService.import(
+        mockEmissionsImport as EmissionsImportDTO,
+        mockLocations as any,
+        1, // reportingPeriodId
+        identifiers as any, // identifiers
+        '2023-01-01T00:00:00Z' // currentTime
+      )).resolves.not.toThrow();
+    });
+
+    it('should find location with both identifiers', async () => {
+      const dailyTestSummaryData = [
+        { unitId: '4', stackPipeId: 'CS2', testTypeCode: 'RATA' }
+      ];
+
+      mockEmissionsImport.dailyTestSummaryData = dailyTestSummaryData;
+
+      const identifiers = {
+        userId: 'testUser',
+        locations: {
+          'LOC3': {
+            components: {},
+            monitorFormulas: {},
+            monitoringSystems: {}
+          }
+        }
+      };
+
+      // Should not throw error for valid both identifiers location
+      await expect(dailyTestSummaryService.import(
+        mockEmissionsImport as EmissionsImportDTO,
+        mockLocations as any,
+        1, // reportingPeriodId
+        identifiers as any, // identifiers
+        '2023-01-01T00:00:00Z' // currentTime
+      )).resolves.not.toThrow();
+    });
+
+    it('should throw error when no location found', async () => {
+      const dailyTestSummaryData = [
+        { unitId: 'NOMATCH', stackPipeId: null, testTypeCode: 'RATA' }
+      ];
+
+      mockEmissionsImport.dailyTestSummaryData = dailyTestSummaryData;
+
+      const identifiers = {
+        userId: 'testUser',
+        locations: {}
+      };
+
+      await expect(
+        dailyTestSummaryService.import(
+          mockEmissionsImport as EmissionsImportDTO,
+          mockLocations as any,
+          1,
+          identifiers as any,
+          '2023-01-01T00:00:00Z'
+        )
+      ).rejects.toThrow(BadRequestException);
+    });
+
+    it('should throw error when multiple locations found', async () => {
+      const ambiguousLocations = [
+        { id: 'LOC1', unit: { name: '3' }, stackPipe: null },
+        { id: 'LOC2', unit: { name: '3' }, stackPipe: null },
+      ];
+
+      const dailyTestSummaryData = [
+        { unitId: '3', stackPipeId: null, testTypeCode: 'RATA' }
+      ];
+
+      mockEmissionsImport.dailyTestSummaryData = dailyTestSummaryData;
+
+      const identifiers = {
+        userId: 'testUser',
+        locations: {}
+      };
+
+      await expect(
+        dailyTestSummaryService.import(
+          mockEmissionsImport as EmissionsImportDTO,
+          ambiguousLocations as any,
+          1,
+          { userId: 'testUser' } as any,
+          '2023-01-01T00:00:00Z'
+        )
+      ).rejects.toThrow(BadRequestException);
+    });
   });
 });

--- a/src/daily-test-summary-workspace/daily-test-summary.service.ts
+++ b/src/daily-test-summary-workspace/daily-test-summary.service.ts
@@ -1,4 +1,4 @@
-import { Injectable } from '@nestjs/common';
+import { BadRequestException, Injectable } from '@nestjs/common';
 import { BulkLoadService } from '@us-epa-camd/easey-common/bulk-load';
 import { randomUUID } from 'crypto';
 import { EntityManager } from 'typeorm';
@@ -111,12 +111,30 @@ export class DailyTestSummaryWorkspaceService {
     );
 
     for (const dailyTestSummaryDatum of emissionsImport.dailyTestSummaryData) {
-      const monitoringLocationId = monitoringLocations.filter(location => {
-        return (
-          location.unit?.name === dailyTestSummaryDatum.unitId ||
-          location.stackPipe?.name === dailyTestSummaryDatum.stackPipeId
+      // Handle anyOf schema - either unitId OR stackPipeId (or both)
+      const matchingLocations = monitoringLocations.filter(location => {
+        if (dailyTestSummaryDatum.unitId && dailyTestSummaryDatum.stackPipeId) {
+          return location.unit?.name === dailyTestSummaryDatum.unitId &&
+                 location.stackPipe?.name === dailyTestSummaryDatum.stackPipeId;
+        } else if (dailyTestSummaryDatum.unitId) {
+          return location.unit?.name === dailyTestSummaryDatum.unitId;
+        } else if (dailyTestSummaryDatum.stackPipeId) {
+          return location.stackPipe?.name === dailyTestSummaryDatum.stackPipeId;
+        }
+        return false;
+      });
+
+      if (matchingLocations.length === 0) {
+        throw new BadRequestException(
+          `No location found for unitId: ${dailyTestSummaryDatum.unitId}, stackPipeId: ${dailyTestSummaryDatum.stackPipeId}`
         );
-      })[0].id;
+      }
+      if (matchingLocations.length > 1) {
+        throw new BadRequestException(
+          'Multiple locations found - unable to determine unique location'
+        );
+      }
+      const monitoringLocationId = matchingLocations[0].id;
 
       const uid = randomUUID();
       dailyTestSummaryDatum['id'] = uid;

--- a/src/emissions-workspace/emissions-checks.service.spec.ts
+++ b/src/emissions-workspace/emissions-checks.service.spec.ts
@@ -1,5 +1,6 @@
 import { Test } from '@nestjs/testing';
 import { BulkLoadModule } from '@us-epa-camd/easey-common/bulk-load';
+import { BadRequestException } from '@nestjs/common';
 import { CheckCatalogService } from '@us-epa-camd/easey-common/check-catalog';
 import { EaseyException } from '@us-epa-camd/easey-common/exceptions/easey.exception';
 import { LoggerModule } from '@us-epa-camd/easey-common/logger';
@@ -254,6 +255,177 @@ describe('Emissions Checks Service Tests', () => {
       await expect(
         service.invalidFormulasCheck(payload, [moniotorLocation]),
       ).resolves.toEqual(undefined);
+    });
+  });
+
+  // Tests Location lookup with anyOf schema compliance
+  describe('Location Lookup - anyOf Schema Compliance', () => {
+    const mockLocations = [
+      {
+        id: 'LOC1',
+        unit: { name: '3' },
+        stackPipe: null
+      },
+      {
+        id: 'LOC2',
+        unit: null,
+        stackPipe: { name: 'CS1' }
+      },
+      {
+        id: 'LOC3',
+        unit: { name: '4' },
+        stackPipe: { name: 'CS2' }
+      },
+    ] as MonitorLocation[];
+
+    beforeEach(() => {
+      jest.spyOn(monitorFormulaRepository, 'find').mockResolvedValue([{ id: '1', formulaId: 'TEST-FORMULA' } as any
+      ]);
+      CheckCatalogService.formatResultMessage = jest.fn().mockImplementation((code, params) => {
+        if (code === 'IMPORT-28-A') {
+          return `Formula ${params?.formulaID} not found`;
+        }
+        return `Mock message for ${code}`;
+      });
+    });
+
+    it('should find location with unitId only', async () => {
+      const today = new Date();
+      const year = today.getFullYear();
+      const quarter = Math.floor(today.getMonth() / 3 + 1);
+      // Create date within the same quarter as payload
+      const quarterStartMonth = (quarter - 1) * 3;
+      const sameQuarterDate = new Date(year, quarterStartMonth, 15); // Mid-month of quarter start
+
+      const payload = {
+        year: year,
+        quarter: quarter,
+        hourlyOperatingData: [
+          {
+            unitId: '3',
+            stackPipeId: null,
+            date: sameQuarterDate,
+            derivedHourlyValueData: [{ formulaId: 'TEST-FORMULA' }]
+          }
+        ]
+
+      } as EmissionsImportDTO;
+
+      // Should not throw error for valid unitId-only location
+      await expect(
+        service.invalidFormulasCheck(payload, mockLocations)
+      ).resolves.not.toThrow();
+    });
+
+    it('should find location with stackPipeId only', async () => {
+      const today = new Date();
+      const year = today.getFullYear();
+      const quarter = Math.floor(today.getMonth() / 3 + 1);
+      // Create date within the same quarter as payload
+      const quarterStartMonth = (quarter - 1) * 3;
+      const sameQuarterDate = new Date(year, quarterStartMonth, 15); // Mid-month of quarter start
+
+      const payload = {
+        year: year,
+        quarter: quarter,
+        hourlyOperatingData: [
+          {
+            unitId: null,
+            stackPipeId: 'CS1',
+            date: sameQuarterDate,
+            derivedHourlyValueData: [{ formulaId: 'TEST-FORMULA' }]
+          }
+        ]
+      } as EmissionsImportDTO;
+
+      // Should not throw error for valid stackPipeId-only location
+      await expect(
+        service.invalidFormulasCheck(payload, mockLocations)
+      ).resolves.not.toThrow();
+    });
+
+    it('should find location with both identifiers', async () => {
+      const today = new Date();
+      const year = today.getFullYear();
+      const quarter = Math.floor(today.getMonth() / 3 + 1);
+      // Create date within the same quarter as payload
+      const quarterStartMonth = (quarter - 1) * 3;
+      const sameQuarterDate = new Date(year, quarterStartMonth, 15); // Mid-month of quarter start
+
+      const payload = {
+        year: year,
+        quarter: quarter,
+        hourlyOperatingData: [
+          {
+            unitId: '4',
+            stackPipeId: 'CS2',
+            date: sameQuarterDate,
+            derivedHourlyValueData: [{ formulaId: 'TEST-FORMULA' }]
+          }
+        ]
+      } as EmissionsImportDTO;
+
+      // Should not throw error for valid both identifiers location
+      await expect(
+        service.invalidFormulasCheck(payload, mockLocations)
+      ).resolves.not.toThrow();
+    });
+
+    it('should throw error when no location found', async () => {
+      const today = new Date();
+      const year = today.getFullYear();
+      const quarter = Math.floor(today.getMonth() / 3 + 1);
+      // Create date within the same quarter as payload
+      const quarterStartMonth = (quarter - 1) * 3;
+      const sameQuarterDate = new Date(year, quarterStartMonth, 15); // Mid-month of quarter start
+
+      const payload = {
+        year: year,
+        quarter: quarter,
+        hourlyOperatingData: [
+          {
+            unitId: '999',
+            stackPipeId: null,
+            date: sameQuarterDate,
+            derivedHourlyValueData: [{ formulaId: 'TEST-FORMULA' }]
+          }
+        ]
+      } as EmissionsImportDTO;
+
+      await expect(
+        service.invalidFormulasCheck(payload, mockLocations)
+      ).rejects.toThrow(BadRequestException);
+    });
+
+    it('should throw error when multiple locations found', async () => {
+      const ambiguousLocations = [
+        { id: 'LOC1', unit: { name: '3' }, stackPipe: null },
+        { id: 'LOC2', unit: { name: '3' }, stackPipe: null }, // Duplicate unit
+      ] as MonitorLocation[];
+
+      const today = new Date();
+      const year = today.getFullYear();
+      const quarter = Math.floor(today.getMonth() / 3 + 1);
+      // Create date within the same quarter as payload
+      const quarterStartMonth = (quarter - 1) * 3;
+      const sameQuarterDate = new Date(year, quarterStartMonth, 15); // Mid-month of quarter start
+
+      const payload = {
+        year: year,
+        quarter: quarter,
+        hourlyOperatingData: [
+          {
+            unitId: '3',
+            stackPipeId: null,
+            date: sameQuarterDate,
+            derivedHourlyValueData: [{ formulaId: 'TEST-FORMULA' }]
+          }
+        ]
+      } as EmissionsImportDTO;
+
+      await expect(
+        service.invalidFormulasCheck(payload, ambiguousLocations)
+      ).rejects.toThrow(BadRequestException);
     });
   });
 });

--- a/src/emissions-workspace/emissions-checks.service.ts
+++ b/src/emissions-workspace/emissions-checks.service.ts
@@ -1,4 +1,4 @@
-import { HttpStatus, Injectable } from '@nestjs/common';
+import { BadRequestException, HttpStatus, Injectable } from '@nestjs/common';
 import { Logger } from '@us-epa-camd/easey-common/logger';
 import { CheckCatalogService } from '@us-epa-camd/easey-common/check-catalog';
 
@@ -117,12 +117,30 @@ export class EmissionsChecksService {
     const identifierMap = new Map<string, Set<string>>();
 
     payload?.hourlyOperatingData?.forEach(hourlyOp => {
-      const monitoringLocationId = monitoringLocations.filter(location => {
-        return (
-          location.unit?.name === hourlyOp.unitId ||
-          location.stackPipe?.name === hourlyOp.stackPipeId
+      // To handle anyOf schema - either unitId OR stackPipeId (or both)
+      const matchingLocations = monitoringLocations.filter(location => {
+        if (hourlyOp.unitId && hourlyOp.stackPipeId) {
+          return location.unit?.name === hourlyOp.unitId &&
+                 location.stackPipe?.name === hourlyOp.stackPipeId;
+        } else if (hourlyOp.unitId) {
+          return location.unit?.name === hourlyOp.unitId;
+        } else if (hourlyOp.stackPipeId) {
+          return location.stackPipe?.name === hourlyOp.stackPipeId;
+        }
+        return false;
+      });
+
+      if (matchingLocations.length === 0) {
+        throw new BadRequestException(
+          `No location found for unitId: ${hourlyOp.unitId}, stackPipeId: ${hourlyOp.stackPipeId}`
         );
-      })[0].id;
+      }
+      if (matchingLocations.length > 1) {
+        throw new BadRequestException(
+          'Multiple locations found - unable to determine unique location'
+        );
+      }
+      const monitoringLocationId = matchingLocations[0].id;
 
       if (!identifierMap.has(monitoringLocationId)) {
         identifierMap.set(monitoringLocationId, new Set());

--- a/src/emissions-workspace/emissions.service.spec.ts
+++ b/src/emissions-workspace/emissions.service.spec.ts
@@ -32,7 +32,7 @@ import { DailyTestSummaryWorkspaceRepository } from '../daily-test-summary-works
 import { DailyTestSummaryWorkspaceService } from '../daily-test-summary-workspace/daily-test-summary.service';
 import { DerivedHourlyValueWorkspaceRepository } from '../derived-hourly-value-workspace/derived-hourly-value-workspace.repository';
 import { DerivedHourlyValueWorkspaceService } from '../derived-hourly-value-workspace/derived-hourly-value-workspace.service';
-import { EmissionsDTO } from '../dto/emissions.dto';
+import { EmissionsDTO, EmissionsImportDTO } from '../dto/emissions.dto';
 import { MonitorLocation } from '../entities/monitor-location.entity';
 import { Plant } from '../entities/plant.entity';
 import { EmissionEvaluation } from '../entities/workspace/emission-evaluation.entity';
@@ -107,7 +107,7 @@ import { SummaryValueDataCheckService } from '../summary-value-workspace/summary
 import { EmissionsService } from '../emissions/emissions.service';
 import { EmissionsParamsDTO } from '../dto/emissions.params.dto';
 import { CurrentUser }      from '@us-epa-camd/easey-common/interfaces';
-import { NotFoundException } from '@nestjs/common';
+import { NotFoundException, BadRequestException } from '@nestjs/common';
 
 describe('Emissions Workspace Service', () => {
   const mockQueryRunner = {
@@ -141,6 +141,7 @@ describe('Emissions Workspace Service', () => {
   let emissionsMap: EmissionsMap;
   let plantRepository: PlantRepository;
   let manager: EntityManager;
+  let bulkLoadService: BulkLoadService;
 
   beforeAll(async () => {
     const module: TestingModule = await Test.createTestingModule({
@@ -153,7 +154,12 @@ describe('Emissions Workspace Service', () => {
         {
           provide: BulkLoadService,
           useValue: {
-            startBulkLoad: jest.fn(),
+            startBulkLoader: jest.fn().mockResolvedValue({
+              writeObject: jest.fn(),
+              complete: jest.fn(),
+              finished: Promise.resolve(true),
+              status: 'Complete',
+            }),
             completeBulkLoad: jest.fn(),
             abortBulkLoad: jest.fn(),
           },
@@ -321,6 +327,7 @@ describe('Emissions Workspace Service', () => {
     emissionsMap = module.get(EmissionsMap);
     plantRepository = module.get(PlantRepository);
     manager = module.get(EntityManager);
+     bulkLoadService = module.get(BulkLoadService);
   });
 
   it('should have a emissions service', function() {
@@ -549,5 +556,201 @@ describe('Emissions Workspace Service', () => {
         new Date().toISOString(),
       ),
     ).resolves;
+    });
+
+  // Tests location lookup with anyOf schema compliance
+  describe('Location Lookup - anyOf Schema Compliance', () => {
+    beforeEach(() => {
+      // Mock bulkLoadService to prevent database connections
+      jest.spyOn(bulkLoadService, 'startBulkLoader').mockResolvedValue({
+        writeObject: jest.fn(),
+        complete: jest.fn().mockResolvedValue(undefined),
+      } as any);
+
+      // Reset database mocks for successful operations (override previous test failures)
+      mockQueryRunner.manager.query.mockResolvedValue([
+        { result: 'S', error_msg: null }
+      ]);
+      mockQueryRunner.manager.save.mockResolvedValue({});
+      mockQueryRunner.manager.insert.mockResolvedValue({});
+      mockQueryRunner.manager.update.mockResolvedValue({});
+
+      // Mock successful ReportingPeriod lookup
+      (mockEntityManager.findOne as jest.Mock).mockResolvedValue({
+        id: 1,
+        year: 2023,
+        quarter: 1,
+      });
+
+      // Mock successful plant lookup with all test locations
+      jest.spyOn(plantRepository, 'getImportPlant').mockResolvedValue({
+        monitorPlans: [{
+          beginRptPeriod: { year: 2023, quarter: 1 },
+          endRptPeriod: null,
+          locations: [
+            { id: 'LOC1', unit: { name: '3' }, stackPipe: null },
+            { id: 'LOC2', unit: null, stackPipe: { name: 'CS1' } },
+            { id: 'LOC3', unit: { name: '4' }, stackPipe: { name: 'CS2' } },
+          ],
+        }]
+      } as any);
+    });
+
+    const mockLocations = [
+      {
+        id: 'LOC1',
+        unit: { name: '3' },
+        stackPipe: null
+      },
+      {
+        id: 'LOC2',
+        unit: null,
+        stackPipe: { name: 'CS1' }
+      },
+      {
+        id: 'LOC3',
+        unit: { name: '4' },
+        stackPipe: { name: 'CS2' }
+      },
+    ];
+
+    it('should find location with unitId only', async () => {
+      const mockEmissionsImportDTO = new EmissionsImportDTO({
+        orisCode: 12345,
+        year: 2023,
+        quarter: 1,
+        dailyEmissionData: [
+        { unitId: '3', stackPipeId: null, parameterCode: 'CO2', dailyFuelData: []  }
+      ],
+        dailyTestSummaryData: [],
+        hourlyOperatingData: [],
+        weeklyTestSummaryData: [],
+        summaryValueData: [],
+        longTermFuelFlowData: [],
+        sorbentTrapData: [],
+        nsps4tSummaryData: [],
+        dailyBackstopData: [],
+      });
+
+      // Should not throw error for valid unitId-only location
+      await expect(emissionsService.import(
+        mockEmissionsImportDTO,
+        'test-user-id'
+      )).resolves.not.toThrow();
+    });
+
+    it('should find location with stackPipeId only', async () => {
+      const mockEmissionsImportDTO = new EmissionsImportDTO( {
+        orisCode: 12345,
+        year: 2023,
+        quarter: 1,
+        dailyEmissionData: [
+          { unitId: null, stackPipeId: 'CS1', parameterCode: 'CO2', dailyFuelData: []  }
+        ],
+        dailyTestSummaryData: [],
+        hourlyOperatingData: [],
+        weeklyTestSummaryData: [],
+        summaryValueData: [],
+        longTermFuelFlowData: [],
+        sorbentTrapData: [],
+        nsps4tSummaryData: [],
+        dailyBackstopData: [],
+      });
+
+      // Should not throw error for valid stackPipeId-only location
+      await expect(emissionsService.import(
+        mockEmissionsImportDTO,
+        'test-user-id'
+      )).resolves.not.toThrow();
+    });
+
+    it('should find location with both identifiers', async () => {
+      const mockEmissionsImportDTO = new EmissionsImportDTO( {
+        orisCode: 12345,
+        year: 2023,
+        quarter: 1,
+        dailyEmissionData: [
+          { unitId: '4', stackPipeId: 'CS2', parameterCode: 'CO2', dailyFuelData: []  }
+      ],
+        dailyTestSummaryData: [],
+        hourlyOperatingData: [],
+        weeklyTestSummaryData: [],
+        summaryValueData: [],
+        longTermFuelFlowData: [],
+        sorbentTrapData: [],
+        nsps4tSummaryData: [],
+        dailyBackstopData: [],
+      });
+
+      // Should not throw error for valid both identifiers location
+      await expect(emissionsService.import(
+        mockEmissionsImportDTO,
+       'test-user-id'
+      )).resolves.not.toThrow();
+    });
+
+    it('should throw error when no location found', async () => {
+      const mockEmissionsImportDTO = new EmissionsImportDTO( {
+        orisCode: 12345,
+        year: 2023,
+        quarter: 1,
+        dailyEmissionData: [
+          { unitId: 'NOMATCH', stackPipeId: null, parameterCode: 'CO2', dailyFuelData: []  }
+      ],
+        dailyTestSummaryData: [],
+        hourlyOperatingData: [],
+        weeklyTestSummaryData: [],
+        summaryValueData: [],
+        longTermFuelFlowData: [],
+        sorbentTrapData: [],
+        nsps4tSummaryData: [],
+        dailyBackstopData: [],
+      });
+
+      await expect(
+        emissionsService.import(
+          mockEmissionsImportDTO,
+          'test-user-id'
+        )
+      ).rejects.toThrow(BadRequestException);
+    });
+
+    it('should throw error when multiple locations found', async () => {
+      // Override plant mock to return ambiguous locations
+      jest.spyOn(plantRepository, 'getImportPlant').mockResolvedValue({
+        monitorPlans: [{
+          beginRptPeriod: { year: 2023, quarter: 1 },
+          endRptPeriod: null,
+          locations: [
+            { id: 'LOC1', unit: { name: '3' }, stackPipe: null },
+            { id: 'LOC2', unit: { name: '3' }, stackPipe: null },
+          ],
+        }]
+      } as any);
+
+       const mockEmissionsImportDTO = new EmissionsImportDTO( {
+        orisCode: 12345,
+        year: 2023,
+        quarter: 1,
+        dailyEmissionData: [
+        { unitId: '3', stackPipeId: null, parameterCode: 'CO2', dailyFuelData: []  }
+        ],
+        dailyTestSummaryData: [],
+        hourlyOperatingData: [],
+        weeklyTestSummaryData: [],
+        summaryValueData: [],
+        longTermFuelFlowData: [],
+        sorbentTrapData: [],
+        nsps4tSummaryData: [],
+        dailyBackstopData: [],
+      });
+
+      await expect(
+        emissionsService.import(
+          mockEmissionsImportDTO,
+          'test-user-id'
+        )
+      ).rejects.toThrow(BadRequestException);
+    });
   });
 });

--- a/src/emissions-workspace/emissions.service.ts
+++ b/src/emissions-workspace/emissions.service.ts
@@ -1,4 +1,4 @@
-import { HttpStatus, Injectable, NotFoundException } from '@nestjs/common';
+import { BadRequestException, HttpStatus, Injectable, NotFoundException } from '@nestjs/common';
 import { EaseyException } from '@us-epa-camd/easey-common/exceptions/easey.exception';
 import { currentDateTime } from '@us-epa-camd/easey-common/utilities/functions';
 import { DeleteResult, EntityManager } from 'typeorm';
@@ -162,8 +162,7 @@ export class EmissionsWorkspaceService {
   }
 
   async import(
-    params: EmissionsImportDTO,
-    userId?: string,
+    params: EmissionsImportDTO, userId?: string, p0?: number, p1?: any, p2?: string, p3?: boolean, p4?: null,
   ): Promise<{ message: string }> {
     // Pre-transaction validation phase - which is only read operations
       const stackPipeIds = objectValuesByKey<string>('stackPipeId', params, true);
@@ -634,12 +633,29 @@ export class EmissionsWorkspaceService {
   async getMonitoringLocationId(
     monitoringLocations: MonitorLocation[], dataType,
   ) {
+    // Handle anyOf schema - either unitId OR stackPipeId (or both)
     const filteredLocations = monitoringLocations.filter(location => {
-      return (
-        location.unit?.name === dataType.unitId ||
-        location.stackPipe?.name === dataType.stackPipeId
-      );
+      if (dataType.unitId && dataType.stackPipeId) {
+        return location.unit?.name === dataType.unitId &&
+               location.stackPipe?.name === dataType.stackPipeId;
+      } else if (dataType.unitId) {
+        return location.unit?.name === dataType.unitId;
+      } else if (dataType.stackPipeId) {
+        return location.stackPipe?.name === dataType.stackPipeId;
+      }
+      return false;
     });
+
+    if (filteredLocations.length === 0) {
+      throw new BadRequestException(
+        `No location found for unitId: ${dataType.unitId}, stackPipeId: ${dataType.stackPipeId}`
+      );
+    }
+    if (filteredLocations.length > 1) {
+      throw new BadRequestException(
+        'Multiple locations found - unable to determine unique location'
+      );
+    }
     return filteredLocations[0].id;
   }
 }

--- a/src/hourly-operating-workspace/hourly-operating.service.spec.ts
+++ b/src/hourly-operating-workspace/hourly-operating.service.spec.ts
@@ -1,5 +1,6 @@
 import { faker } from '@faker-js/faker';
 import { Test } from '@nestjs/testing';
+import { BadRequestException } from '@nestjs/common';
 import { BulkLoadService } from '@us-epa-camd/easey-common/bulk-load';
 import { EntityManager } from 'typeorm';
 
@@ -64,11 +65,13 @@ const mockRepository = {
 const mockMonitorHourlyValueService = {
   export: () => Promise.resolve([new MonitorHourlyValueDTO()]),
   import: jest.fn().mockResolvedValue(true),
+  buildObjectList: jest.fn().mockResolvedValue([]),
 };
 
 const mockHourlyGasFlowMeterService = {
   export: () => Promise.resolve([new HourlyGasFlowMeterDTO()]),
   import: jest.fn().mockResolvedValue(true),
+  buildObjectList: jest.fn().mockResolvedValue([]),
 };
 
 const mockDerivedHourlyValueService = () => {
@@ -79,17 +82,26 @@ const mockDerivedHourlyValueService = () => {
   return {
     export: () => Promise.resolve(generatedDerivedHrlyValues),
     import: jest.fn().mockResolvedValue(true),
+    buildObjectList: jest.fn().mockResolvedValue([]),
   };
 };
 
 const mockMatsMonitorHourlyValueService = {
   export: () => Promise.resolve([new MatsMonitorHourlyValueDTO()]),
   import: jest.fn().mockResolvedValue(true),
+  buildObjectList: jest.fn().mockResolvedValue([]),
 };
 
 const mockMatsDerivedHourlyValueService = {
   export: () => Promise.resolve([new MatsDerivedHourlyValueDTO()]),
   import: jest.fn().mockResolvedValue(true),
+  buildObjectList: jest.fn().mockResolvedValue([]),
+};
+
+const mockHourlyFuelFlowService = {
+  export: jest.fn().mockResolvedValue([]),
+  import: jest.fn().mockResolvedValue(true),
+  buildObjectList: jest.fn().mockResolvedValue([]),
 };
 
 const writeObjectMock = jest.fn();
@@ -138,7 +150,8 @@ describe('HourlyOperatingWorskpaceService', () => {
             startBulkLoader: jest.fn().mockResolvedValue({
               writeObject: writeObjectMock,
               complete: jest.fn(),
-              finished: true,
+              finished: Promise.resolve(true),
+              status: 'Complete',
             }),
           }),
         },
@@ -161,6 +174,10 @@ describe('HourlyOperatingWorskpaceService', () => {
         {
           provide: HourlyGasFlowMeterWorkspaceService,
           useValue: mockHourlyGasFlowMeterService,
+        },
+        {
+          provide: HourlyFuelFlowWorkspaceService,
+          useValue: mockHourlyFuelFlowService,
         },
         {
           provide: HourlyOperatingWorkspaceRepository,
@@ -228,6 +245,12 @@ describe('HourlyOperatingWorskpaceService', () => {
         new HourlyOperatingImportDTO(),
       ];
 
+      // Valid unitId/stackPipeId to test data
+      dto.hourlyOperatingData[0].unitId = '3';
+      dto.hourlyOperatingData[0].stackPipeId = null;
+      dto.hourlyOperatingData[1].unitId = '4';
+      dto.hourlyOperatingData[1].stackPipeId = null;
+
       const identifiers = { locations: {}, userId: '' };
       const monitoringLocationId = faker.datatype.string();
       identifiers.locations[monitoringLocationId] = {
@@ -236,15 +259,177 @@ describe('HourlyOperatingWorskpaceService', () => {
         monitoringSystems: {},
       };
 
+      const mockLocations = [
+        {
+          id: 'LOC1',
+          unit: { name: '3' },
+          stackPipe: null,
+        },
+        {
+          id: 'LOC2',
+          unit: { name: '4' },
+          stackPipe: null,
+        },
+      ];
+
       await service.import(
         dto,
-        [MonitorLocation],
+        mockLocations as any,
         1,
         identifiers,
         new Date().toISOString(),
       );
 
       expect(writeObjectMock).toHaveBeenCalledTimes(2);
+    });
+  });
+
+  // Location lookup with anyOf schema compliance
+  describe('Location Lookup - anyOf Schema Compliance', () => {
+    const mockLocations = [
+      {
+        id: 'LOC1',
+        unit: { name: '3' },
+        stackPipe: null
+      },
+      {
+        id: 'LOC2',
+        unit: null,
+        stackPipe: { name: 'CS1' }
+      },
+      {
+        id: 'LOC3',
+        unit: { name: '4' },
+        stackPipe: { name: 'CS2' }
+      },
+    ] as MonitorLocation[];
+
+    it('should find location with unitId only', async () => {
+      const dto = new EmissionsImportDTO();
+      dto.hourlyOperatingData = [
+        {
+          unitId: '3',
+          stackPipeId: null,
+          date: new Date(),
+          hour: 1,
+          derivedHourlyValueData: [],
+          matsMonitorHourlyValueData: [],
+          monitorHourlyValueData: [],
+          matsDerivedHourlyValueData: [],
+          hourlyFuelFlowData: [],
+          hourlyGFMData: [],
+        } as HourlyOperatingImportDTO,
+      ];
+
+      const identifiers = { locations: {}, userId: 'test-user' };
+
+      // Should not throw error for valid unitId-only location
+      await expect(
+        service.import(dto, mockLocations, 1, identifiers, new Date().toISOString())
+      ).resolves.not.toThrow();
+    });
+
+    it('should find location with stackPipeId only', async () => {
+      const dto = new EmissionsImportDTO();
+      dto.hourlyOperatingData = [
+        {
+          unitId: null,
+          stackPipeId: 'CS1',
+          date: new Date(),
+          hour: 1,
+          derivedHourlyValueData: [],
+          matsMonitorHourlyValueData: [],
+          monitorHourlyValueData: [],
+          matsDerivedHourlyValueData: [],
+          hourlyFuelFlowData: [],
+          hourlyGFMData: [],
+        } as HourlyOperatingImportDTO,
+      ];
+
+      const identifiers = { locations: {}, userId: 'test-user' };
+
+      // Should not throw error for valid stackPipeId-only location
+      await expect(
+        service.import(dto, mockLocations, 1, identifiers, new Date().toISOString())
+      ).resolves.not.toThrow();
+    });
+
+    it('should find location with both identifiers', async () => {
+      const dto = new EmissionsImportDTO();
+      dto.hourlyOperatingData = [
+        {
+          unitId: '4',
+          stackPipeId: 'CS2',
+          date: new Date(),
+          hour: 1,
+          derivedHourlyValueData: [],
+          matsMonitorHourlyValueData: [],
+          monitorHourlyValueData: [],
+          matsDerivedHourlyValueData: [],
+          hourlyFuelFlowData: [],
+          hourlyGFMData: [],
+        } as HourlyOperatingImportDTO,
+      ];
+
+      const identifiers = { locations: {}, userId: 'test-user' };
+
+      // Should not throw error for valid both identifiers location
+      await expect(
+        service.import(dto, mockLocations, 1, identifiers, new Date().toISOString())
+      ).resolves.not.toThrow();
+    });
+
+    it('should throw error when no location found', async () => {
+      const dto = new EmissionsImportDTO();
+      dto.hourlyOperatingData = [
+        {
+          unitId: '999',
+          stackPipeId: null,
+          date: new Date(),
+          hour: 1,
+          derivedHourlyValueData: [],
+          matsMonitorHourlyValueData: [],
+          monitorHourlyValueData: [],
+          matsDerivedHourlyValueData: [],
+          hourlyFuelFlowData: [],
+          hourlyGFMData: [],
+        } as HourlyOperatingImportDTO,
+      ];
+
+      const identifiers = { locations: {}, userId: 'test-user' };
+
+      await expect(
+        service.import(dto, mockLocations, 1, identifiers, new Date().toISOString())
+      ).rejects.toThrow(BadRequestException);
+    });
+
+    it('should throw error when multiple locations found', async () => {
+      const ambiguousLocations = [
+        { id: 'LOC1', unit: { name: '3' }, stackPipe: null },
+        { id: 'LOC2', unit: { name: '3' }, stackPipe: null }, // Duplicate unit
+      ] as MonitorLocation[];
+
+      const dto = new EmissionsImportDTO();
+      dto.hourlyOperatingData = [
+        {
+          unitId: '3',
+          stackPipeId: null,
+          date: new Date(),
+          hour: 1,
+          derivedHourlyValueData: [],
+          matsMonitorHourlyValueData: [],
+          monitorHourlyValueData: [],
+          matsDerivedHourlyValueData: [],
+          hourlyFuelFlowData: [],
+          hourlyGFMData: [],
+        } as HourlyOperatingImportDTO,
+      ];
+
+      const identifiers = { locations: {}, userId: 'test-user' };
+
+      await expect(
+        service.import(dto, ambiguousLocations, 1, identifiers, new Date().toISOString())
+      ).rejects.toThrow(BadRequestException);
     });
   });
 });

--- a/src/hourly-operating-workspace/hourly-operating.service.ts
+++ b/src/hourly-operating-workspace/hourly-operating.service.ts
@@ -1,4 +1,4 @@
-import { HttpStatus, Injectable } from '@nestjs/common';
+import { BadRequestException, HttpStatus, Injectable } from '@nestjs/common';
 import { BulkLoadService } from '@us-epa-camd/easey-common/bulk-load';
 import { EaseyException } from '@us-epa-camd/easey-common/exceptions/easey.exception';
 import { randomUUID } from 'crypto';
@@ -128,12 +128,30 @@ export class HourlyOperatingWorkspaceService {
       trx?.queryRunner,
     ); // Instantiate our stream object with the correct schema.tableName we want to load to
     for (const hourlyOperatingDatum of emissionsImport.hourlyOperatingData) {
-      const monitoringLocationId = monitoringLocations.filter(location => {
-        return (
-          location.unit?.name === hourlyOperatingDatum.unitId ||
-          location.stackPipe?.name === hourlyOperatingDatum.stackPipeId
+      // To handle anyOf schema - either unitId OR stackPipeId (or both)
+      const matchingLocations = monitoringLocations.filter(location => {
+        if (hourlyOperatingDatum.unitId && hourlyOperatingDatum.stackPipeId) {
+          return location.unit?.name === hourlyOperatingDatum.unitId &&
+                 location.stackPipe?.name === hourlyOperatingDatum.stackPipeId;
+        } else if (hourlyOperatingDatum.unitId) {
+          return location.unit?.name === hourlyOperatingDatum.unitId;
+        } else if (hourlyOperatingDatum.stackPipeId) {
+          return location.stackPipe?.name === hourlyOperatingDatum.stackPipeId;
+        }
+        return false;
+      });
+
+      if (matchingLocations.length === 0) {
+        throw new BadRequestException(
+          `No location found for unitId: ${hourlyOperatingDatum.unitId}, stackPipeId: ${hourlyOperatingDatum.stackPipeId}`
         );
-      })[0].id;
+      }
+      if (matchingLocations.length > 1) {
+        throw new BadRequestException(
+          'Multiple locations found - unable to determine unique location'
+        );
+      }
+      const monitoringLocationId = matchingLocations[0].id;
       //We must load the parent first because the children records require the parents uid
       const uid = randomUUID();
       hourlyOperatingDatum['id'] = uid; //Set the id on our dto object so we can access it again when loading the children
@@ -183,12 +201,30 @@ export class HourlyOperatingWorkspaceService {
       const hourlyGasFlowMeterObjects = [];
 
       for (const hourlyOperatingDatum of emissionsImport.hourlyOperatingData) {
-        const monitoringLocationId = monitoringLocations.filter(location => {
-          return (
-            location.unit?.name === hourlyOperatingDatum.unitId ||
-            location.stackPipe?.name === hourlyOperatingDatum.stackPipeId
+        // To handle anyOf schema - either unitId OR stackPipeId (or both)
+        const matchingLocations = monitoringLocations.filter(location => {
+          if (hourlyOperatingDatum.unitId && hourlyOperatingDatum.stackPipeId) {
+            return location.unit?.name === hourlyOperatingDatum.unitId &&
+                   location.stackPipe?.name === hourlyOperatingDatum.stackPipeId;
+          } else if (hourlyOperatingDatum.unitId) {
+            return location.unit?.name === hourlyOperatingDatum.unitId;
+          } else if (hourlyOperatingDatum.stackPipeId) {
+            return location.stackPipe?.name === hourlyOperatingDatum.stackPipeId;
+          }
+          return false;
+        });
+
+        if (matchingLocations.length === 0) {
+          throw new BadRequestException(
+            `No location found for unitId: ${hourlyOperatingDatum.unitId}, stackPipeId: ${hourlyOperatingDatum.stackPipeId}`
           );
-        })[0].id;
+        }
+        if (matchingLocations.length > 1) {
+          throw new BadRequestException(
+            'Multiple locations found - unable to determine unique location'
+          );
+        }
+        const monitoringLocationId = matchingLocations[0].id;
 
         //Load children records in a bulk fashion as well
         buildPromises.push(

--- a/src/long-term-fuel-flow-workspace/long-term-fuel-flow.service.spec.ts
+++ b/src/long-term-fuel-flow-workspace/long-term-fuel-flow.service.spec.ts
@@ -1,5 +1,6 @@
 import { Test } from '@nestjs/testing';
 import { faker } from '@faker-js/faker';
+import { BadRequestException } from '@nestjs/common';
 
 import { mockLongTermFuelFlowWorkspaceRepository } from '../../test/mocks/mock-long-term-fuel-flow-workspace-repository';
 import { LongTermFuelFlowWorkspaceRepository } from './long-term-fuel-flow.repository';
@@ -11,7 +12,11 @@ import { EmissionsParamsDTO } from '../dto/emissions.params.dto';
 import { BulkLoadService } from '@us-epa-camd/easey-common/bulk-load';
 import { ConfigService } from '@nestjs/config';
 import { EmissionsImportDTO } from '../dto/emissions.dto';
+import { LongTermFuelFlowImportDTO } from '../dto/long-term-fuel-flow.dto';
+import { MonitorLocation } from '../entities/monitor-location.entity';
 import { ImportIdentifiers } from '../emissions-workspace/emissions.service';
+
+const writeObjectMock = jest.fn();
 
 describe('--LongTermFuelFlowWorkspaceService--', () => {
   let repository: LongTermFuelFlowWorkspaceRepository;
@@ -24,8 +29,18 @@ describe('--LongTermFuelFlowWorkspaceService--', () => {
       providers: [
         LongTermFuelFlowWorkspaceService,
         LongTermFuelFlowMap,
-        BulkLoadService,
         ConfigService,
+        {
+          provide: BulkLoadService,
+          useFactory: () => ({
+            startBulkLoader: jest.fn().mockResolvedValue({
+              writeObject: writeObjectMock,
+              complete: jest.fn(),
+              finished: Promise.resolve(true),
+              status: 'Complete',
+            }),
+          }),
+        },
         {
           provide: LongTermFuelFlowWorkspaceRepository,
           useValue: mockLongTermFuelFlowWorkspaceRepository,
@@ -46,26 +61,21 @@ describe('--LongTermFuelFlowWorkspaceService--', () => {
     const mockedData = genLongTermFuelFlow<LongTermFuelFlow>(1);
     const longTermFuelFlow = await map.many(mockedData);
 
-    //@ts-expect-error as mock
-    jest.spyOn(bulkLoadService, 'startBulkLoader').mockResolvedValue({
-      writeObject: jest.fn(),
-      complete: jest.fn(),
-      finished: Promise.resolve(true),
-    });
-
     const emissionsDto = new EmissionsImportDTO();
     emissionsDto.longTermFuelFlowData = longTermFuelFlow;
 
-    const locations = [{ unit: { name: '1' }, id: 1 }];
+    // MonitorLocation objects with valid structure
+    const locations = [{ unit: { name: '1' }, id: '1', stackPipe: null }];
 
     longTermFuelFlow[0].unitId = '1';
+    longTermFuelFlow[0].stackPipeId = null;
     const identifiers = { locations: {}, userId: '' };
     const monitoringLocationId = faker.datatype.string();
     identifiers.locations[monitoringLocationId] = { components: {}, monitorFormulas: {}, monitoringSystems: {} };
 
     await expect(
-      service.import(emissionsDto, locations, '1', identifiers, '2019-01-01'),
-    ).resolves;
+      service.import(emissionsDto, locations, 1, identifiers, '2019-01-01'),
+    ).resolves.not.toThrow();
   });
   it('should get long term fuel flow by location ids', async function () {
     const genLongTermFuelFlowValues = genLongTermFuelFlow<LongTermFuelFlow>(1);
@@ -85,5 +95,129 @@ describe('--LongTermFuelFlowWorkspaceService--', () => {
       params,
     );
     expect(result).toEqual(mappedValues);
+  });
+
+  // TT6932 Tests: Location lookup with anyOf schema compliance
+  describe('Location Lookup - anyOf Schema Compliance', () => {
+    const mockLocations = [
+      {
+        id: 'LOC1',
+        unit: { name: '3' },
+        stackPipe: null
+      },
+      {
+        id: 'LOC2',
+        unit: null,
+        stackPipe: { name: 'CS1' }
+      },
+      {
+        id: 'LOC3',
+        unit: { name: '4' },
+        stackPipe: { name: 'CS2' }
+      },
+    ] as MonitorLocation[];
+
+    it('should find location with unitId only', async () => {
+      const dto = new EmissionsImportDTO();
+      dto.longTermFuelFlowData = [
+        {
+          unitId: '3',
+          stackPipeId: null,
+          monitoringSystemId: 'SYS1',
+          fuelFlowPeriodCode: 'Q1',
+          longTermFuelFlowValue: 100,
+        } as LongTermFuelFlowImportDTO,
+      ];
+
+      const identifiers = { locations: {}, userId: 'test-user' };
+
+      // Should not throw error for valid unitId-only location
+      await expect(
+        service.import(dto, mockLocations, 1, identifiers, new Date().toISOString())
+      ).resolves.not.toThrow();
+    });
+
+    it('should find location with stackPipeId only', async () => {
+      const dto = new EmissionsImportDTO();
+      dto.longTermFuelFlowData = [
+        {
+          unitId: null,
+          stackPipeId: 'CS1',
+          monitoringSystemId: 'SYS1',
+          fuelFlowPeriodCode: 'Q1',
+          longTermFuelFlowValue: 100,
+        } as LongTermFuelFlowImportDTO,
+      ];
+
+      const identifiers = { locations: {}, userId: 'test-user' };
+
+      // Should not throw error for valid stackPipeId-only location
+      await expect(
+        service.import(dto, mockLocations, 1, identifiers, new Date().toISOString())
+      ).resolves.not.toThrow();
+    });
+
+    it('should find location with both identifiers', async () => {
+      const dto = new EmissionsImportDTO();
+      dto.longTermFuelFlowData = [
+        {
+          unitId: '4',
+          stackPipeId: 'CS2',
+          monitoringSystemId: 'SYS1',
+          fuelFlowPeriodCode: 'Q1',
+          longTermFuelFlowValue: 100,
+        } as LongTermFuelFlowImportDTO,
+      ];
+
+      const identifiers = { locations: {}, userId: 'test-user' };
+
+      // Should not throw error for valid both identifiers location
+      await expect(
+        service.import(dto, mockLocations, 1, identifiers, new Date().toISOString())
+      ).resolves.not.toThrow();
+    });
+
+    it('should throw error when no location found', async () => {
+      const dto = new EmissionsImportDTO();
+      dto.longTermFuelFlowData = [
+        {
+          unitId: '999',
+          stackPipeId: null,
+          monitoringSystemId: 'SYS1',
+          fuelFlowPeriodCode: 'Q1',
+          longTermFuelFlowValue: 100,
+        } as LongTermFuelFlowImportDTO,
+      ];
+
+      const identifiers = { locations: {}, userId: 'test-user' };
+
+      await expect(
+        service.import(dto, mockLocations, 1, identifiers, new Date().toISOString())
+      ).rejects.toThrow(BadRequestException);
+    });
+
+    it('should throw error when multiple locations found', async () => {
+      const ambiguousLocations = [
+        { id: 'LOC1', unit: { name: '3' }, stackPipe: null },
+        { id: 'LOC2', unit: { name: '3' }, stackPipe: null }, // Duplicate unit
+      ] as MonitorLocation[];
+
+      const dto = new EmissionsImportDTO();
+      dto.longTermFuelFlowData = [
+        {
+          unitId: '3',
+          stackPipeId: null,
+          monitoringSystemId: 'SYS1',
+          fuelFlowPeriodCode: 'Q1',
+          longTermFuelFlowValue: 100,
+        } as LongTermFuelFlowImportDTO,
+      ];
+
+      const identifiers = { locations: {}, userId: 'test-user' };
+
+      await expect(
+        service.import(dto, ambiguousLocations, 1, identifiers, new Date().toISOString())
+      ).rejects.toThrow(BadRequestException);
+    });
   });
 });

--- a/src/long-term-fuel-flow-workspace/long-term-fuel-flow.service.ts
+++ b/src/long-term-fuel-flow-workspace/long-term-fuel-flow.service.ts
@@ -1,4 +1,4 @@
-import { Injectable } from '@nestjs/common';
+import { BadRequestException, Injectable } from '@nestjs/common';
 import { BulkLoadService } from '@us-epa-camd/easey-common/bulk-load';
 import { randomUUID } from 'crypto';
 import { DeleteResult, EntityManager } from 'typeorm';
@@ -72,12 +72,30 @@ export class LongTermFuelFlowWorkspaceService {
     );
 
     for (const longTermFuelFlowDatum of emissionsImport.longTermFuelFlowData) {
-      const monitoringLocationId = monitoringLocations.filter(location => {
-        return (
-          location.unit?.name === longTermFuelFlowDatum.unitId ||
-          location.stackPipe?.name === longTermFuelFlowDatum.stackPipeId
+      // Fix for TT6932: Handle anyOf schema - either unitId OR stackPipeId (or both)
+      const matchingLocations = monitoringLocations.filter(location => {
+        if (longTermFuelFlowDatum.unitId && longTermFuelFlowDatum.stackPipeId) {
+          return location.unit?.name === longTermFuelFlowDatum.unitId &&
+                 location.stackPipe?.name === longTermFuelFlowDatum.stackPipeId;
+        } else if (longTermFuelFlowDatum.unitId) {
+          return location.unit?.name === longTermFuelFlowDatum.unitId;
+        } else if (longTermFuelFlowDatum.stackPipeId) {
+          return location.stackPipe?.name === longTermFuelFlowDatum.stackPipeId;
+        }
+        return false;
+      });
+
+      if (matchingLocations.length === 0) {
+        throw new BadRequestException(
+          `No location found for unitId: ${longTermFuelFlowDatum.unitId}, stackPipeId: ${longTermFuelFlowDatum.stackPipeId}`
         );
-      })[0].id;
+      }
+      if (matchingLocations.length > 1) {
+        throw new BadRequestException(
+          'Multiple locations found - unable to determine unique location'
+        );
+      }
+      const monitoringLocationId = matchingLocations[0].id;
 
       const uid = randomUUID();
       longTermFuelFlowDatum['id'] = uid;

--- a/src/nsps4t-summary-workspace/nsps4t-summary-workspace.service.spec.ts
+++ b/src/nsps4t-summary-workspace/nsps4t-summary-workspace.service.spec.ts
@@ -1,5 +1,6 @@
 import { faker } from '@faker-js/faker';
 import { ConfigService } from '@nestjs/config';
+import { BadRequestException } from '@nestjs/common';
 import { Test, TestingModule } from '@nestjs/testing';
 import { BulkLoadService } from '@us-epa-camd/easey-common/bulk-load';
 import { EntityManager } from 'typeorm';
@@ -7,6 +8,8 @@ import { EntityManager } from 'typeorm';
 import { genNsps4tSummary } from '../../test/object-generators/nsps4t-summary';
 import { EmissionsImportDTO } from '../dto/emissions.dto';
 import { EmissionsParamsDTO } from '../dto/emissions.params.dto';
+import { Nsps4tSummaryImportDTO } from '../dto/nsps4t-summary.dto';
+import { MonitorLocation } from '../entities/monitor-location.entity';
 import { Nsps4tSummary } from '../entities/workspace/nsps4t-summary.entity';
 import { Nsps4tSummaryMap } from '../maps/nsps4t-summary.map';
 import { Nsps4tAnnualWorkspaceRepository } from '../nsps4t-annual-workspace/nsps4t-annual-workspace.repository';
@@ -16,6 +19,21 @@ import { Nsps4tCompliancePeriodWorkspaceService } from '../nsps4t-compliance-per
 import * as exportNsps4tSummaryData from '../nsps4t-summary-functions/export-nsps4t-summary-data';
 import { Nsps4tSummaryWorkspaceRepository } from './nsps4t-summary-workspace.repository';
 import { Nsps4tSummaryWorkspaceService } from './nsps4t-summary-workspace.service';
+
+const writeObjectMock = jest.fn();
+
+// Mock child services with all required methods
+const mockNsps4tAnnualService = {
+  export: jest.fn().mockResolvedValue([]),
+  buildObjectList: jest.fn().mockResolvedValue([]),
+  import: jest.fn().mockResolvedValue(undefined),
+};
+
+const mockNsps4tCompliancePeriodService = {
+  export: jest.fn().mockResolvedValue([]),
+  buildObjectList: jest.fn().mockResolvedValue([]),
+  import: jest.fn().mockResolvedValue(undefined),
+};
 
 describe('Nsps4tSummaryWorkspaceNewService', () => {
   let service: Nsps4tSummaryWorkspaceService;
@@ -30,14 +48,30 @@ describe('Nsps4tSummaryWorkspaceNewService', () => {
       providers: [
         EntityManager,
         Nsps4tAnnualWorkspaceRepository,
-        Nsps4tAnnualWorkspaceService,
         Nsps4tCompliancePeriodWorkspaceRepository,
-        Nsps4tCompliancePeriodWorkspaceService,
         Nsps4tSummaryWorkspaceRepository,
         Nsps4tSummaryWorkspaceService,
         Nsps4tSummaryMap,
-        BulkLoadService,
         ConfigService,
+        {
+          provide: BulkLoadService,
+          useFactory: () => ({
+            startBulkLoader: jest.fn().mockResolvedValue({
+              writeObject: writeObjectMock,
+              complete: jest.fn(),
+              finished: Promise.resolve(true),
+              status: 'Complete',
+            }),
+          }),
+        },
+        {
+          provide: Nsps4tAnnualWorkspaceService,
+          useValue: mockNsps4tAnnualService,
+        },
+        {
+          provide: Nsps4tCompliancePeriodWorkspaceService,
+          useValue: mockNsps4tCompliancePeriodService,
+        },
       ],
     }).compile();
 
@@ -65,10 +99,6 @@ describe('Nsps4tSummaryWorkspaceNewService', () => {
       .spyOn(exportNsps4tSummaryData, 'exportNsps4tSummaryData')
       .mockResolvedValue(mappedValues);
 
-    jest.spyOn(annualService, 'export').mockResolvedValue([]);
-
-    jest.spyOn(compliancePeriodService, 'export').mockResolvedValue([]);
-
     await expect(service.export([], new EmissionsParamsDTO())).resolves.toEqual(
       mappedValues,
     );
@@ -82,19 +112,14 @@ describe('Nsps4tSummaryWorkspaceNewService', () => {
     });
     const nsps4tSummaryData = await map.many(entityMocks);
 
-    //@ts-expect-error as mock
-    jest.spyOn(bulkLoadService, 'startBulkLoader').mockResolvedValue({
-      writeObject: jest.fn(),
-      complete: jest.fn(),
-      finished: Promise.resolve(true),
-    });
-
     const emissionsDto = new EmissionsImportDTO();
     emissionsDto.nsps4tSummaryData = nsps4tSummaryData;
 
-    const locations = [{ unit: { name: '1' }, id: 1 }];
+    // MonitorLocation objects with valid structure
+    const locations = [{ unit: { name: '1' }, id: '1', stackPipe: null }];
 
     nsps4tSummaryData[0].unitId = '1';
+    nsps4tSummaryData[0].stackPipeId = null;
     const identifiers = { locations: {}, userId: '' };
     const monitoringLocationId = faker.datatype.string();
     identifiers.locations[monitoringLocationId] = {
@@ -104,7 +129,131 @@ describe('Nsps4tSummaryWorkspaceNewService', () => {
     };
 
     await expect(
-      service.import(emissionsDto, locations, '1', identifiers, '2019-01-01'),
-    ).resolves;
+      service.import(emissionsDto, locations, 1, identifiers, '2019-01-01'),
+    ).resolves.not.toThrow();
+     });
+
+  // Location lookup with anyOf schema compliance
+  describe('Location Lookup - anyOf Schema Compliance', () => {
+    const mockLocations = [
+      {
+        id: 'LOC1',
+        unit: { name: '3' },
+        stackPipe: null
+      },
+      {
+        id: 'LOC2',
+        unit: null,
+        stackPipe: { name: 'CS1' }
+      },
+      {
+        id: 'LOC3',
+        unit: { name: '4' },
+        stackPipe: { name: 'CS2' }
+      },
+    ] as MonitorLocation[];
+
+    it('should find location with unitId only', async () => {
+      const dto = new EmissionsImportDTO();
+      dto.nsps4tSummaryData = [
+        {
+          unitId: '3',
+          stackPipeId: null,
+          co2EmissionStandardCode: 'STANDARD1',
+          nsps4tFourthQuarterData: [],
+          nsps4tCompliancePeriodData: [],
+        } as Nsps4tSummaryImportDTO,
+      ];
+
+    const identifiers = { locations: {}, userId: 'test-user' };
+
+      // Should not throw error for valid unitId-only location
+      await expect(
+        service.import(dto, mockLocations, 1, identifiers, new Date().toISOString())
+      ).resolves.not.toThrow();
+    });
+
+    it('should find location with stackPipeId only', async () => {
+      const dto = new EmissionsImportDTO();
+      dto.nsps4tSummaryData = [
+        {
+          unitId: null,
+          stackPipeId: 'CS1',
+          co2EmissionStandardCode: 'STANDARD1',
+          nsps4tFourthQuarterData: [],
+          nsps4tCompliancePeriodData: [],
+        } as Nsps4tSummaryImportDTO,
+      ];
+
+      const identifiers = { locations: {}, userId: 'test-user' };
+
+      // Should not throw error for valid stackPipeId-only location
+      await expect(
+        service.import(dto, mockLocations, 1, identifiers, new Date().toISOString())
+      ).resolves.not.toThrow();
+    });
+
+    it('should find location with both identifiers', async () => {
+      const dto = new EmissionsImportDTO();
+      dto.nsps4tSummaryData = [
+        {
+          unitId: '4',
+          stackPipeId: 'CS2',
+          co2EmissionStandardCode: 'STANDARD1',
+          nsps4tFourthQuarterData: [],
+          nsps4tCompliancePeriodData: [],
+        } as Nsps4tSummaryImportDTO,
+      ];
+
+      const identifiers = { locations: {}, userId: 'test-user' };
+
+      // Should not throw error for valid both identifiers location
+      await expect(
+        service.import(dto, mockLocations, 1, identifiers, new Date().toISOString())
+      ).resolves.not.toThrow();
+    });
+
+    it('should throw error when no location found', async() => {
+      const dto = new EmissionsImportDTO();
+      dto.nsps4tSummaryData = [
+        {
+          unitId: '999',
+          stackPipeId: null,
+          co2EmissionStandardCode: 'STANDARD1',
+          nsps4tFourthQuarterData: [],
+          nsps4tCompliancePeriodData: [],
+        } as Nsps4tSummaryImportDTO,
+      ];
+
+      const identifiers = { locations: {}, userId: 'test-user' };
+
+      await expect(
+        service.import(dto, mockLocations, 1, identifiers, new Date().toISOString())
+      ).rejects.toThrow(BadRequestException);
+    });
+
+    it('should throw error when multiple locations found', async() => {
+      const ambiguousLocations = [
+        { id: 'LOC1', unit: { name: '3' }, stackPipe: null },
+        { id: 'LOC2', unit: { name: '3' }, stackPipe: null }, // Duplicate unit
+      ] as MonitorLocation[];
+
+      const dto = new EmissionsImportDTO();
+      dto.nsps4tSummaryData = [
+        {
+          unitId: '3',
+          stackPipeId: null,
+          co2EmissionStandardCode: 'STANDARD1',
+          nsps4tFourthQuarterData: [],
+          nsps4tCompliancePeriodData: [],
+        } as Nsps4tSummaryImportDTO,
+      ];
+
+     const identifiers = { locations: {}, userId: 'test-user' };
+
+      await expect(
+        service.import(dto, ambiguousLocations, 1, identifiers, new Date().toISOString())
+      ).rejects.toThrow(BadRequestException);
+    });
   });
 });

--- a/src/nsps4t-summary-workspace/nsps4t-summary-workspace.service.ts
+++ b/src/nsps4t-summary-workspace/nsps4t-summary-workspace.service.ts
@@ -1,4 +1,4 @@
-import { HttpStatus, Injectable } from '@nestjs/common';
+import { BadRequestException, HttpStatus, Injectable } from '@nestjs/common';
 import { BulkLoadService } from '@us-epa-camd/easey-common/bulk-load';
 import { EaseyException } from '@us-epa-camd/easey-common/exceptions/easey.exception';
 import { randomUUID } from 'crypto';
@@ -96,12 +96,30 @@ export class Nsps4tSummaryWorkspaceService {
     );
 
     for (const nsps4tSummaryDatum of emissionsImport.nsps4tSummaryData) {
-      const monitoringLocationId = monitoringLocations.filter(location => {
-        return (
-          location.unit?.name === nsps4tSummaryDatum.unitId ||
-          location.stackPipe?.name === nsps4tSummaryDatum.stackPipeId
+      // Fix for TT6932: Handle anyOf schema - either unitId OR stackPipeId (or both)
+      const matchingLocations = monitoringLocations.filter(location => {
+        if (nsps4tSummaryDatum.unitId && nsps4tSummaryDatum.stackPipeId) {
+          return location.unit?.name === nsps4tSummaryDatum.unitId &&
+                 location.stackPipe?.name === nsps4tSummaryDatum.stackPipeId;
+        } else if (nsps4tSummaryDatum.unitId) {
+          return location.unit?.name === nsps4tSummaryDatum.unitId;
+        } else if (nsps4tSummaryDatum.stackPipeId) {
+          return location.stackPipe?.name === nsps4tSummaryDatum.stackPipeId;
+        }
+        return false;
+      });
+
+      if (matchingLocations.length === 0) {
+        throw new BadRequestException(
+          `No location found for unitId: ${nsps4tSummaryDatum.unitId}, stackPipeId: ${nsps4tSummaryDatum.stackPipeId}`
         );
-      })[0].id;
+     }
+      if (matchingLocations.length > 1) {
+        throw new BadRequestException(
+          'Multiple locations found - unable to determine unique location'
+        );
+      }
+      const monitoringLocationId = matchingLocations[0].id;
 
       const uid = randomUUID();
       nsps4tSummaryDatum['id'] = uid;
@@ -132,12 +150,30 @@ export class Nsps4tSummaryWorkspaceService {
       const nsps4tCompliancePeriodObjects = [];
 
       for (const nsps4tSummaryDatum of emissionsImport.nsps4tSummaryData) {
-        const monitoringLocationId = monitoringLocations.filter(location => {
-          return (
-            location.unit?.name === nsps4tSummaryDatum.unitId ||
-            location.stackPipe?.name === nsps4tSummaryDatum.stackPipeId
+        // Handle anyOf schema - either unitId OR stackPipeId (or both)
+        const matchingLocations = monitoringLocations.filter(location => {
+          if (nsps4tSummaryDatum.unitId && nsps4tSummaryDatum.stackPipeId) {
+            return location.unit?.name === nsps4tSummaryDatum.unitId &&
+                   location.stackPipe?.name === nsps4tSummaryDatum.stackPipeId;
+          } else if (nsps4tSummaryDatum.unitId) {
+            return location.unit?.name === nsps4tSummaryDatum.unitId;
+          } else if (nsps4tSummaryDatum.stackPipeId) {
+            return location.stackPipe?.name === nsps4tSummaryDatum.stackPipeId;
+          }
+          return false;
+        });
+
+        if (matchingLocations.length === 0) {
+          throw new BadRequestException(
+            `No location found for unitId: ${nsps4tSummaryDatum.unitId}, stackPipeId: ${nsps4tSummaryDatum.stackPipeId}`
           );
-        })[0].id;
+        }
+        if (matchingLocations.length > 1) {
+          throw new BadRequestException(
+            'Multiple locations found - unable to determine unique location'
+          );
+        }
+        const monitoringLocationId = matchingLocations[0].id;
 
         buildPromises.push(
           this.nsps4tAnnualService.buildObjectList(

--- a/src/sorbent-trap-workspace/sorbent-trap-workspace.service.spec.ts
+++ b/src/sorbent-trap-workspace/sorbent-trap-workspace.service.spec.ts
@@ -1,5 +1,6 @@
 import { faker } from '@faker-js/faker';
 import { ConfigService } from '@nestjs/config';
+import { BadRequestException } from '@nestjs/common';
 import { Test, TestingModule } from '@nestjs/testing';
 import { BulkLoadService } from '@us-epa-camd/easey-common/bulk-load';
 import { EntityManager } from 'typeorm';
@@ -8,6 +9,8 @@ import { genSorbentTrap } from '../../test/object-generators/sorbent-trap';
 import { ComponentRepository } from '../component/component.repository';
 import { EmissionsImportDTO } from '../dto/emissions.dto';
 import { EmissionsParamsDTO } from '../dto/emissions.params.dto';
+import { SorbentTrapImportDTO } from '../dto/sorbent-trap.dto';
+import { MonitorLocation } from '../entities/monitor-location.entity';
 import { SorbentTrap } from '../entities/workspace/sorbent-trap.entity';
 import { SorbentTrapMap } from '../maps/sorbent-trap.map';
 import { MonitorSystemRepository } from '../monitor-system/monitor-system.repository';
@@ -16,6 +19,15 @@ import { SamplingTrainWorkspaceService } from '../sampling-train-workspace/sampl
 import * as exportSorbentTrapData from '../sorbent-trap-functions/export-sorbent-trap-data';
 import { SorbentTrapWorkspaceRepository } from './sorbent-trap-workspace.repository';
 import { SorbentTrapWorkspaceService } from './sorbent-trap-workspace.service';
+
+const writeObjectMock = jest.fn();
+
+// Mock child service with all required methods
+const mockSamplingTrainService = {
+  export: jest.fn().mockResolvedValue([]),
+  buildObjectList: jest.fn().mockResolvedValue([]),
+  import: jest.fn().mockResolvedValue(undefined),
+};
 
 describe('SorbentTrapWorkspaceService', () => {
   let service: SorbentTrapWorkspaceService;
@@ -26,16 +38,29 @@ describe('SorbentTrapWorkspaceService', () => {
   beforeEach(async () => {
     const module: TestingModule = await Test.createTestingModule({
       providers: [
-        EntityManager,
-        ComponentRepository,
-        MonitorSystemRepository,
-        SamplingTrainWorkspaceService,
         SorbentTrapWorkspaceService,
-        SamplingTrainWorkspaceRepository,
-        SorbentTrapWorkspaceRepository,
         SorbentTrapMap,
-        BulkLoadService,
-        ConfigService,
+        {
+          provide: SorbentTrapWorkspaceRepository,
+          useValue: {
+            delete: jest.fn(),
+          },
+        },
+        {
+          provide: BulkLoadService,
+          useFactory: () => ({
+            startBulkLoader: jest.fn().mockResolvedValue({
+              writeObject: writeObjectMock,
+              complete: jest.fn(),
+              finished: Promise.resolve(true),
+              status: 'Complete',
+            }),
+          }),
+        },
+        {
+          provide: SamplingTrainWorkspaceService,
+          useValue: mockSamplingTrainService,
+        },
       ],
     }).compile();
 
@@ -100,5 +125,144 @@ describe('SorbentTrapWorkspaceService', () => {
     await expect(
       service.import(emissionsDto, locations, '1', identifiers, '2019-01-01'),
     ).resolves;
+     });
+
+  // Location lookup with anyOf schema compliance
+  describe('Location Lookup - anyOf Schema Compliance', () => {
+    const mockLocations = [
+      {
+        id: 'LOC1',
+        unit: { name: '3' },
+        stackPipe: null
+      },
+      {
+        id: 'LOC2',
+        unit: null,
+        stackPipe: { name: 'CS1' }
+      },
+      {
+        id: 'LOC3',
+        unit: { name: '4' },
+        stackPipe: { name: 'CS2' }
+      },
+    ] as MonitorLocation[];
+
+    it('should find location with unitId only', async () => {
+      const dto = new EmissionsImportDTO();
+      dto.sorbentTrapData = [
+        {
+          unitId: '3',
+          stackPipeId: null,
+          beginDate: new Date('2023-01-01'),
+          beginHour: 0,
+          endDate: new Date('2023-01-01'),
+          endHour: 23,
+          monitoringSystemId: 'SYS1',
+          samplingTrainData: [],
+        } as SorbentTrapImportDTO,
+      ];
+
+      const identifiers = { locations: {}, userId: 'test-user' };
+
+      // Should not throw error for valid unitId-only location
+      await expect(
+        service.import(dto, mockLocations, '1', identifiers, new Date().toISOString())
+      ).resolves.not.toThrow();
+    });
+
+    it('should find location with stackPipeId only', async () => {
+      const dto = new EmissionsImportDTO();
+      dto.sorbentTrapData = [
+        {
+          unitId: null,
+          stackPipeId: 'CS1',
+          beginDate: new Date('2023-01-01'),
+          beginHour: 0,
+          endDate: new Date('2023-01-01'),
+          endHour: 23,
+          monitoringSystemId: 'SYS1',
+          samplingTrainData: [],
+        } as SorbentTrapImportDTO,
+      ];
+
+      const identifiers = { locations: {}, userId: 'test-user' };
+
+      // Should not throw error for valid stackPipeId-only location
+      await expect(
+        service.import(dto, mockLocations, '1', identifiers, new Date().toISOString())
+      ).resolves.not.toThrow();
+    });
+
+    it('should find location with both identifiers', async () => {
+      const dto = new EmissionsImportDTO();
+      dto.sorbentTrapData = [
+        {
+          unitId: '4',
+          stackPipeId: 'CS2',
+          beginDate: new Date('2023-01-01'),
+          beginHour: 0,
+          endDate: new Date('2023-01-01'),
+          endHour: 23,
+          monitoringSystemId: 'SYS1',
+          samplingTrainData: [],
+        } as SorbentTrapImportDTO,
+      ];
+
+      const identifiers = { locations: {}, userId: 'test-user' };
+
+      // Should not throw error for valid both identifiers location
+      await expect(
+        service.import(dto, mockLocations, '1', identifiers, new Date().toISOString())
+      ).resolves.not.toThrow();
+    });
+
+    it('should throw error when no location found', async () => {
+      const dto = new EmissionsImportDTO();
+      dto.sorbentTrapData = [
+        {
+          unitId: '999',
+          stackPipeId: null,
+          beginDate: new Date('2023-01-01'),
+          beginHour: 0,
+          endDate: new Date('2023-01-01'),
+          endHour: 23,
+          monitoringSystemId: 'SYS1',
+          samplingTrainData: [],
+        } as SorbentTrapImportDTO,
+      ];
+
+      const identifiers = { locations: {}, userId: 'test-user' };
+
+      await expect(
+        service.import(dto, mockLocations, '1', identifiers, new Date().toISOString())
+      ).rejects.toThrow(BadRequestException);
+    });
+
+    it('should throw error when multiple locations found', async () => {
+      const ambiguousLocations = [
+        { id: 'LOC1', unit: { name: '3' }, stackPipe: null },
+        { id: 'LOC2', unit: { name: '3' }, stackPipe: null }, // Duplicate unit
+      ] as MonitorLocation[];
+
+      const dto = new EmissionsImportDTO();
+      dto.sorbentTrapData = [
+        {
+          unitId: '3',
+          stackPipeId: null,
+          beginDate: new Date('2023-01-01'),
+          beginHour: 0,
+          endDate: new Date('2023-01-01'),
+          endHour: 23,
+          monitoringSystemId: 'SYS1',
+          samplingTrainData: [],
+        } as SorbentTrapImportDTO,
+      ];
+
+      const identifiers = { locations: {}, userId: 'test-user' };
+
+      await expect(
+        service.import(dto, ambiguousLocations, '1', identifiers, new Date().toISOString())
+      ).rejects.toThrow(BadRequestException);
+    });
   });
 });

--- a/src/sorbent-trap-workspace/sorbent-trap-workspace.service.ts
+++ b/src/sorbent-trap-workspace/sorbent-trap-workspace.service.ts
@@ -1,4 +1,4 @@
-import { Injectable } from '@nestjs/common';
+import { BadRequestException, Injectable } from '@nestjs/common';
 import { BulkLoadService } from '@us-epa-camd/easey-common/bulk-load';
 import { randomUUID } from 'crypto';
 import { DeleteResult, EntityManager } from 'typeorm';
@@ -88,12 +88,30 @@ export class SorbentTrapWorkspaceService {
     );
 
     for (const sorbentTrapDatum of emissionsImport.sorbentTrapData) {
-      const monitoringLocationId = monitoringLocations.filter(location => {
-        return (
-          location.unit?.name === sorbentTrapDatum.unitId ||
-          location.stackPipe?.name === sorbentTrapDatum.stackPipeId
+      // Handle anyOf schema - either unitId OR stackPipeId (or both)
+      const matchingLocations = monitoringLocations.filter(location => {
+        if (sorbentTrapDatum.unitId && sorbentTrapDatum.stackPipeId) {
+          return location.unit?.name === sorbentTrapDatum.unitId &&
+                 location.stackPipe?.name === sorbentTrapDatum.stackPipeId;
+        } else if (sorbentTrapDatum.unitId) {
+          return location.unit?.name === sorbentTrapDatum.unitId;
+        } else if (sorbentTrapDatum.stackPipeId) {
+          return location.stackPipe?.name === sorbentTrapDatum.stackPipeId;
+        }
+        return false;
+      });
+
+      if (matchingLocations.length === 0) {
+        throw new BadRequestException(
+          `No location found for unitId: ${sorbentTrapDatum.unitId}, stackPipeId: ${sorbentTrapDatum.stackPipeId}`
         );
-      })[0].id;
+      }
+      if (matchingLocations.length > 1) {
+        throw new BadRequestException(
+          'Multiple locations found - unable to determine unique location'
+        );
+      }
+      const monitoringLocationId = matchingLocations[0].id;
 
       const uid = randomUUID();
       sorbentTrapDatum['id'] = uid;
@@ -131,12 +149,30 @@ export class SorbentTrapWorkspaceService {
       const samplingTrainObjects = [];
 
       for (const sorbentTrapDatum of emissionsImport.sorbentTrapData) {
-        const monitoringLocationId = monitoringLocations.filter(location => {
-          return (
-            location.unit?.name === sorbentTrapDatum.unitId ||
-            location.stackPipe?.name === sorbentTrapDatum.stackPipeId
+        // Handle anyOf schema - either unitId OR stackPipeId (or both)
+        const matchingLocations = monitoringLocations.filter(location => {
+          if (sorbentTrapDatum.unitId && sorbentTrapDatum.stackPipeId) {
+            return location.unit?.name === sorbentTrapDatum.unitId &&
+                   location.stackPipe?.name === sorbentTrapDatum.stackPipeId;
+          } else if (sorbentTrapDatum.unitId) {
+            return location.unit?.name === sorbentTrapDatum.unitId;
+          } else if (sorbentTrapDatum.stackPipeId) {
+            return location.stackPipe?.name === sorbentTrapDatum.stackPipeId;
+          }
+          return false;
+        });
+
+        if (matchingLocations.length === 0) {
+          throw new BadRequestException(
+            `No location found for unitId: ${sorbentTrapDatum.unitId}, stackPipeId: ${sorbentTrapDatum.stackPipeId}`
           );
-        })[0].id;
+        }
+        if (matchingLocations.length > 1) {
+          throw new BadRequestException(
+            'Multiple locations found - unable to determine unique location'
+          );
+        }
+        const monitoringLocationId = matchingLocations[0].id;
         buildPromises.push(
           this.samplingTrainService.buildObjectList(
             sorbentTrapDatum.samplingTrainData,

--- a/src/summary-value-workspace/summary-value.service.spec.ts
+++ b/src/summary-value-workspace/summary-value.service.spec.ts
@@ -1,5 +1,6 @@
 import { Test } from '@nestjs/testing';
 import { faker } from '@faker-js/faker';
+import { BadRequestException } from '@nestjs/common';
 
 import { SummaryValueWorkspaceService } from './summary-value.service';
 import { SummaryValueMap } from '../maps/summary-value.map';
@@ -12,7 +13,11 @@ import { EmissionsParamsDTO } from '../dto/emissions.params.dto';
 import { BulkLoadService } from '@us-epa-camd/easey-common/bulk-load';
 import { ConfigService } from '@nestjs/config';
 import { EmissionsImportDTO } from '../dto/emissions.dto';
+import { SummaryValueImportDTO } from '../dto/summary-value.dto';
+import { MonitorLocation } from '../entities/monitor-location.entity';
 import { ImportIdentifiers } from '../emissions-workspace/emissions.service';
+
+const writeObjectMock = jest.fn();
 
 const mockRepository = {
   ...mockRepositoryFunctions,
@@ -30,8 +35,18 @@ describe('Summary Value Workspace Service Test', () => {
       providers: [
         SummaryValueWorkspaceService,
         SummaryValueMap,
-        BulkLoadService,
         ConfigService,
+        {
+          provide: BulkLoadService,
+          useFactory: () => ({
+            startBulkLoader: jest.fn().mockResolvedValue({
+              writeObject: writeObjectMock,
+              complete: jest.fn(),
+              finished: Promise.resolve(true),
+              status: 'Complete',
+            }),
+          }),
+        },
         {
           provide: SummaryValueWorkspaceRepository,
           useValue: mockRepository,
@@ -89,6 +104,135 @@ describe('Summary Value Workspace Service Test', () => {
         params,
       );
       expect(r).toEqual(mappedSumValues);
+      });
+  });
+
+  // Location lookup with anyOf schema compliance
+  describe('Location Lookup - anyOf Schema Compliance', () => {
+    const mockLocations = [
+      {
+        id: 'LOC1',
+        unit: { name: '3' },
+        stackPipe: null
+      },
+      {
+        id: 'LOC2',
+        unit: null,
+        stackPipe: { name: 'CS1' }
+      },
+      {
+        id: 'LOC3',
+        unit: { name: '4' },
+        stackPipe: { name: 'CS2' }
+      },
+    ] as MonitorLocation[];
+
+    it('should find location with unitId only', async () => {
+      const dto = new EmissionsImportDTO();
+      dto.summaryValueData = [
+        {
+          unitId: '3',
+          stackPipeId: null,
+          parameterCode: 'NOX',
+          currentReportingPeriodTotal: 100,
+          ozoneSeasonToDateTotal: 200,
+          yearToDateTotal: 300,
+        } as SummaryValueImportDTO,
+      ];
+
+      const identifiers = { locations: {}, userId: 'test-user' };
+
+      // Should not throw error for valid unitId-only location
+      await expect(
+        service.import(dto, mockLocations, 1, identifiers, new Date().toISOString())
+      ).resolves.not.toThrow();
+    });
+
+    it('should find location with stackPipeId only', async () => {
+      const dto = new EmissionsImportDTO();
+      dto.summaryValueData = [
+        {
+          unitId: null,
+          stackPipeId: 'CS1',
+          parameterCode: 'NOX',
+          currentReportingPeriodTotal: 100,
+          ozoneSeasonToDateTotal: 200,
+          yearToDateTotal: 300,
+        } as SummaryValueImportDTO,
+      ];
+
+      const identifiers = { locations: {}, userId: 'test-user' };
+
+      // Should not throw error for valid stackPipeId-only location
+      await expect(
+        service.import(dto, mockLocations, 1, identifiers, new Date().toISOString())
+      ).resolves.not.toThrow();
+    });
+
+    it('should find location with both identifiers', async () => {
+      const dto = new EmissionsImportDTO();
+      dto.summaryValueData = [
+        {
+          unitId: '4',
+          stackPipeId: 'CS2',
+          parameterCode: 'NOX',
+          currentReportingPeriodTotal: 100,
+          ozoneSeasonToDateTotal: 200,
+          yearToDateTotal: 300,
+        } as SummaryValueImportDTO,
+      ];
+
+      const identifiers = { locations: {}, userId: 'test-user' };
+
+      // Should not throw error for valid both identifiers location
+      await expect(
+        service.import(dto, mockLocations, 1, identifiers, new Date().toISOString())
+      ).resolves.not.toThrow();
+    });
+
+    it('should throw error when no location found', async () => {
+      const dto = new EmissionsImportDTO();
+      dto.summaryValueData = [
+        {
+          unitId: '999',
+          stackPipeId: null,
+          parameterCode: 'NOX',
+          currentReportingPeriodTotal: 100,
+          ozoneSeasonToDateTotal: 200,
+          yearToDateTotal: 300,
+        } as SummaryValueImportDTO,
+      ];
+
+      const identifiers = { locations: {}, userId: 'test-user' };
+
+      await expect(
+        service.import(dto, mockLocations, 1, identifiers, new Date().toISOString())
+      ).rejects.toThrow(BadRequestException);
+    });
+
+    it('should throw error when multiple locations found', async () => {
+      const ambiguousLocations = [
+        { id: 'LOC1', unit: { name: '3' }, stackPipe: null },
+        { id: 'LOC2', unit: { name: '3' }, stackPipe: null }, // Duplicate unit
+      ] as MonitorLocation[];
+
+      const dto = new EmissionsImportDTO();
+      dto.summaryValueData = [
+        {
+          unitId: '3',
+          stackPipeId: null,
+          parameterCode: 'NOX',
+          currentReportingPeriodTotal: 100,
+          ozoneSeasonToDateTotal: 200,
+          yearToDateTotal: 300,
+        } as SummaryValueImportDTO,
+      ];
+
+      const identifiers = { locations: {}, userId: 'test-user' };
+
+      await expect(
+        service.import(dto, ambiguousLocations, 1, identifiers, new Date().toISOString())
+      ).rejects.toThrow(BadRequestException);
     });
   });
 });

--- a/src/summary-value-workspace/summary-value.service.spec.ts
+++ b/src/summary-value-workspace/summary-value.service.spec.ts
@@ -6,7 +6,7 @@ import { SummaryValueWorkspaceService } from './summary-value.service';
 import { SummaryValueMap } from '../maps/summary-value.map';
 import { SummaryValueWorkspaceRepository } from './summary-value.repository';
 import { genSummaryValueImportDto } from '../../test/object-generators/summary-value-dto';
-import { mockRepositoryFunctions } from '../../test/mocks/mock-repository-functions';
+//import { mockRepositoryFunctions } from '../../test/mocks/mock-repository-functions';
 import { genSummaryValue } from '../../test/object-generators/summary-value';
 import { SummaryValue } from '../entities/workspace/summary-value.entity';
 import { EmissionsParamsDTO } from '../dto/emissions.params.dto';
@@ -20,7 +20,13 @@ import { ImportIdentifiers } from '../emissions-workspace/emissions.service';
 const writeObjectMock = jest.fn();
 
 const mockRepository = {
-  ...mockRepositoryFunctions,
+  create: jest.fn(),
+  save: jest.fn(),
+  find: jest.fn(),
+  insert: jest.fn(),
+  upsert: jest.fn(),
+  update: jest.fn(),
+  delete: jest.fn(),
   export: jest.fn(),
 };
 
@@ -59,8 +65,12 @@ describe('Summary Value Workspace Service Test', () => {
     bulkLoadService = module.get(BulkLoadService);
     map = module.get(SummaryValueMap);
 
+    // Reset and configure mocks for each test
+    writeObjectMock.mockClear();
     repository.save.mockResolvedValue(null);
     repository.find.mockResolvedValue(genSummaryValue<SummaryValue>(1));
+      repository.delete.mockResolvedValue({ affected: 1 });
+      repository.export.mockResolvedValue([]);
   });
 
   describe('Summary Value Import', () => {

--- a/src/summary-value-workspace/summary-value.service.ts
+++ b/src/summary-value-workspace/summary-value.service.ts
@@ -1,4 +1,4 @@
-import { Injectable } from '@nestjs/common';
+import { BadRequestException, Injectable } from '@nestjs/common';
 import { BulkLoadService } from '@us-epa-camd/easey-common/bulk-load';
 import { randomUUID } from 'crypto';
 import { DeleteResult, EntityManager } from 'typeorm';
@@ -79,12 +79,30 @@ export class SummaryValueWorkspaceService {
     );
 
     for (const summaryValueDatum of emissionsImport.summaryValueData) {
-      const monitoringLocationId = monitoringLocations.filter(location => {
-        return (
-          location.unit?.name === summaryValueDatum.unitId ||
-          location.stackPipe?.name === summaryValueDatum.stackPipeId
+      // Handle anyOf schema - either unitId OR stackPipeId (or both)
+      const matchingLocations = monitoringLocations.filter(location => {
+        if (summaryValueDatum.unitId && summaryValueDatum.stackPipeId) {
+          return location.unit?.name === summaryValueDatum.unitId &&
+                 location.stackPipe?.name === summaryValueDatum.stackPipeId;
+        } else if (summaryValueDatum.unitId) {
+          return location.unit?.name === summaryValueDatum.unitId;
+        } else if (summaryValueDatum.stackPipeId) {
+          return location.stackPipe?.name === summaryValueDatum.stackPipeId;
+        }
+        return false;
+      });
+
+      if (matchingLocations.length === 0) {
+        throw new BadRequestException(
+          `No location found for unitId: ${summaryValueDatum.unitId}, stackPipeId: ${summaryValueDatum.stackPipeId}`
         );
-      })[0].id;
+      }
+      if (matchingLocations.length > 1) {
+        throw new BadRequestException(
+          'Multiple locations found - unable to determine unique location'
+        );
+      }
+      const monitoringLocationId = matchingLocations[0].id;
 
       const uid = randomUUID();
       summaryValueDatum['id'] = uid;

--- a/src/weekly-test-summary-workspace/weekly-test-summary.service.spec.ts
+++ b/src/weekly-test-summary-workspace/weekly-test-summary.service.spec.ts
@@ -1,5 +1,6 @@
 import { faker } from '@faker-js/faker';
 import { ConfigService } from '@nestjs/config';
+import { BadRequestException } from '@nestjs/common';
 import { Test } from '@nestjs/testing';
 import { BulkLoadService } from '@us-epa-camd/easey-common/bulk-load';
 import { EntityManager } from 'typeorm';
@@ -15,6 +16,17 @@ import { WeeklySystemIntegrityWorkspaceRepository } from '../weekly-system-integ
 import { WeeklySystemIntegrityWorkspaceService } from '../weekly-system-integrity-workspace/weekly-system-integrity.service';
 import { WeeklyTestSummaryWorkspaceRepository } from './weekly-test-summary.repository';
 import { WeeklyTestSummaryWorkspaceService } from './weekly-test-summary.service';
+import { WeeklyTestSummaryImportDTO } from '../dto/weekly-test-summary.dto';
+import { MonitorLocation } from '../entities/monitor-location.entity';
+
+const writeObjectMock = jest.fn();
+
+// Mock child service with all required methods
+const mockWeeklySystemIntegrityService = {
+  export: jest.fn().mockResolvedValue([]),
+  buildObjectList: jest.fn().mockResolvedValue([]),
+  import: jest.fn().mockResolvedValue(undefined),
+};
 
 describe('--WeeklyTestSummaryWorkspaceService--', () => {
   let map: WeeklyTestSummaryMap;
@@ -26,17 +38,27 @@ describe('--WeeklyTestSummaryWorkspaceService--', () => {
   beforeEach(async () => {
     const module = await Test.createTestingModule({
       providers: [
-        EntityManager,
-        WeeklyTestSummaryMap,
         WeeklyTestSummaryWorkspaceService,
-        WeeklySystemIntegrityWorkspaceService,
-        WeeklySystemIntegrityMap,
-        WeeklySystemIntegrityWorkspaceRepository,
-        BulkLoadService,
+        WeeklyTestSummaryMap,
         ConfigService,
+        {
+          provide: BulkLoadService,
+          useFactory: () => ({
+            startBulkLoader: jest.fn().mockResolvedValue({
+              writeObject: writeObjectMock,
+              complete: jest.fn(),
+              finished: Promise.resolve(true),
+              status: 'Complete',
+            }),
+          }),
+        },
         {
           provide: WeeklyTestSummaryWorkspaceRepository,
           useValue: mockWeeklyTestSummaryWorkspaceRepository,
+        },
+        {
+          provide: WeeklySystemIntegrityWorkspaceService,
+          useValue: mockWeeklySystemIntegrityService,
         },
       ],
     }).compile();
@@ -113,6 +135,155 @@ describe('--WeeklyTestSummaryWorkspaceService--', () => {
 
       await expect(service.import(emissionsDto, locations, '', identifiers, ''))
         .resolves;
+       });
+  });
+
+  // TT6932 Tests: Location lookup with anyOf schema compliance
+  describe('Location Lookup - anyOf Schema Compliance', () => {
+    const mockLocations = [
+      {
+        id: 'LOC1',
+        unit: { name: '3' },
+        stackPipe: null
+      },
+      {
+        id: 'LOC2',
+        unit: null,
+        stackPipe: { name: 'CS1' }
+      },
+      {
+        id: 'LOC3',
+        unit: { name: '4' },
+        stackPipe: { name: 'CS2' }
+      },
+    ] as MonitorLocation[];
+
+    it('should find location with unitId only', async () => {
+      const dto = new EmissionsImportDTO();
+      dto.weeklyTestSummaryData = [
+        {
+          unitId: '3',
+          stackPipeId: null,
+          date: new Date('2023-01-01'),
+          hour: 1,
+          monitoringSystemId: 'SYS1',
+          componentId: 'COMP1',
+          testTypeCode: 'LINEARITY',
+          testResultCode: 'PASSED',
+          spanScaleCode: 'H',
+          weeklySystemIntegrityData: [],
+        } as WeeklyTestSummaryImportDTO,
+      ];
+
+      const identifiers = { locations: {}, userId: 'test-user' };
+
+      // Should not throw error for valid unitId-only location
+      await expect(
+        service.import(dto, mockLocations, '1', identifiers, new Date().toISOString())
+      ).resolves.not.toThrow();
+    });
+
+    it('should find location with stackPipeId only', async () => {
+      const dto = new EmissionsImportDTO();
+      dto.weeklyTestSummaryData = [
+        {
+          unitId: null,
+          stackPipeId: 'CS1',
+          date: new Date('2023-01-01'),
+          hour: 1,
+          monitoringSystemId: 'SYS1',
+          componentId: 'COMP1',
+          testTypeCode: 'LINEARITY',
+          testResultCode: 'PASSED',
+          spanScaleCode: 'H',
+          weeklySystemIntegrityData: [],
+        } as WeeklyTestSummaryImportDTO,
+      ];
+
+      const identifiers = { locations: {}, userId: 'test-user' };
+
+      // Should not throw error for valid stackPipeId-only location
+      await expect(
+        service.import(dto, mockLocations, '1', identifiers, new Date().toISOString())
+      ).resolves.not.toThrow();
+    });
+
+    it('should find location with both identifiers', async () => {
+      const dto = new EmissionsImportDTO();
+      dto.weeklyTestSummaryData = [
+        {
+          unitId: '4',
+          stackPipeId: 'CS2',
+          date: new Date('2023-01-01'),
+          hour: 1,
+          monitoringSystemId: 'SYS1',
+          componentId: 'COMP1',
+          testTypeCode: 'LINEARITY',
+          testResultCode: 'PASSED',
+          spanScaleCode: 'H',
+          weeklySystemIntegrityData: [],
+        } as WeeklyTestSummaryImportDTO,
+      ];
+
+      const identifiers = { locations: {}, userId: 'test-user' };
+
+      // Should not throw error for valid both identifiers location
+      await expect(
+        service.import(dto, mockLocations, '1', identifiers, new Date().toISOString())
+      ).resolves.not.toThrow();
+    });
+
+    it('should throw error when no location found', async () => {
+      const dto = new EmissionsImportDTO();
+      dto.weeklyTestSummaryData = [
+        {
+          unitId: '999',
+          stackPipeId: null,
+          date: new Date('2023-01-01'),
+          hour: 1,
+          monitoringSystemId: 'SYS1',
+          componentId: 'COMP1',
+          testTypeCode: 'LINEARITY',
+          testResultCode: 'PASSED',
+          spanScaleCode: 'H',
+          weeklySystemIntegrityData: [],
+        } as WeeklyTestSummaryImportDTO,
+      ];
+
+      const identifiers = { locations: {}, userId: 'test-user' };
+
+      await expect(
+        service.import(dto, mockLocations, '1', identifiers, new Date().toISOString())
+      ).rejects.toThrow(BadRequestException);
+    });
+
+    it('should throw error when multiple locations found', async () => {
+      const ambiguousLocations = [
+        { id: 'LOC1', unit: { name: '3' }, stackPipe: null },
+        { id: 'LOC2', unit: { name: '3' }, stackPipe: null }, // Duplicate unit
+      ] as MonitorLocation[];
+
+      const dto = new EmissionsImportDTO();
+      dto.weeklyTestSummaryData = [
+        {
+          unitId: '3',
+          stackPipeId: null,
+          date: new Date('2023-01-01'),
+          hour: 1,
+          monitoringSystemId: 'SYS1',
+          componentId: 'COMP1',
+          testTypeCode: 'LINEARITY',
+          testResultCode: 'PASSED',
+          spanScaleCode: 'H',
+          weeklySystemIntegrityData: [],
+        } as WeeklyTestSummaryImportDTO,
+      ];
+
+      const identifiers = { locations: {}, userId: 'test-user' };
+
+      await expect(
+        service.import(dto, ambiguousLocations, '1', identifiers, new Date().toISOString())
+      ).rejects.toThrow(BadRequestException);
     });
   });
 });

--- a/src/weekly-test-summary-workspace/weekly-test-summary.service.ts
+++ b/src/weekly-test-summary-workspace/weekly-test-summary.service.ts
@@ -1,4 +1,4 @@
-import { Injectable } from '@nestjs/common';
+import { BadRequestException, Injectable } from '@nestjs/common';
 import { BulkLoadService } from '@us-epa-camd/easey-common/bulk-load';
 import { randomUUID } from 'crypto';
 import { DeleteResult, EntityManager } from 'typeorm';
@@ -107,12 +107,30 @@ export class WeeklyTestSummaryWorkspaceService {
     );
 
     for (const weeklyTestSummaryDatum of emissionsImport.weeklyTestSummaryData) {
-      const monitoringLocationId = monitoringLocations.filter(location => {
-        return (
-          location.unit?.name === weeklyTestSummaryDatum.unitId ||
-          location.stackPipe?.name === weeklyTestSummaryDatum.stackPipeId
+      // Handle anyOf schema - either unitId OR stackPipeId (or both)
+      const matchingLocations = monitoringLocations.filter(location => {
+        if (weeklyTestSummaryDatum.unitId && weeklyTestSummaryDatum.stackPipeId) {
+          return location.unit?.name === weeklyTestSummaryDatum.unitId &&
+                 location.stackPipe?.name === weeklyTestSummaryDatum.stackPipeId;
+        } else if (weeklyTestSummaryDatum.unitId) {
+          return location.unit?.name === weeklyTestSummaryDatum.unitId;
+        } else if (weeklyTestSummaryDatum.stackPipeId) {
+          return location.stackPipe?.name === weeklyTestSummaryDatum.stackPipeId;
+        }
+        return false;
+      });
+
+      if (matchingLocations.length === 0) {
+        throw new BadRequestException(
+          `No location found for unitId: ${weeklyTestSummaryDatum.unitId}, stackPipeId: ${weeklyTestSummaryDatum.stackPipeId}`
         );
-      })[0].id;
+      }
+      if (matchingLocations.length > 1) {
+        throw new BadRequestException(
+          'Multiple locations found - unable to determine unique location'
+        );
+      }
+      const monitoringLocationId = matchingLocations[0].id;
 
       const uid = randomUUID();
       weeklyTestSummaryDatum['id'] = uid;


### PR DESCRIPTION
### Summary: 
- Users experiencing import crashes with error: `"Cannot read properties of undefined (reading 'locationId')"` when importing QA/EM files containing only `unitId` OR `stackPipeId` (not both). JSON schema uses `anyOf` validation but code required both fields.
### Changes Made: 
- Updated unsafe location lookup patterns across 3 APIs
- All QA/EM/MP files with single identifiers process correctly
- Enhanced error messages guide users toward resolution

### Tests: 
- Unit test validated single identifier lookups (`unitId` only, `stackPipeId` only, both)
- Error handling tests -- verify `BadRequestException` behavior
- Edge case tests -- handle empty/null values safely
```
