### PR TITLE
Fix/6980 undefined access

### DIFF
--- a/src/dto/nsps4t-summary.dto.ts
+++ b/src/dto/nsps4t-summary.dto.ts
@@ -86,12 +86,14 @@ export class Nsps4tSummaryImportDTO extends Nsps4tSummaryBaseDTO {
   @Type(() => Nsps4tCompliancePeriodImportDTO)
   @ArrayMinSize(0)
   @ArrayMaxSize(3)
+  @IsOptional()
   nsps4tCompliancePeriodData?: Nsps4tCompliancePeriodImportDTO[];
 
   @ValidateNested({ each: true })
   @Type(() => Nsps4tAnnualImportDTO)
   @ArrayMinSize(0)
   @ArrayMaxSize(1)
+  @IsOptional()
   nsps4tFourthQuarterData?: Nsps4tAnnualImportDTO[];
 }
 

--- a/src/dto/sorbent-trap.dto.ts
+++ b/src/dto/sorbent-trap.dto.ts
@@ -103,6 +103,7 @@ export class SorbentTrapImportDTO extends SorbentTrapBaseDTO {
   @Type(() => SamplingTrainImportDTO)
   @ArrayMinSize(2)
   @ArrayMaxSize(2)
+  @IsOptional()
   samplingTrainData?: SamplingTrainImportDTO[];
 }
 


### PR DESCRIPTION
## Related Issues:

- https://github.com/US-EPA-CAMD/easey-ui/issues/6980

## Main Changes:

- Added the `@IsOptional()` annotation to several import DTOs. This is usually not necessary for array types with the `@ValidateNested()` annotation, but must be explicit for these types due to the other array length constraints.