### PR TITLE
fix: refresh_emission_view call with master connection

### DIFF
--- a/src/emission-view/emissions-view.service.ts
+++ b/src/emission-view/emissions-view.service.ts
@@ -1,7 +1,7 @@
 import { Request } from 'express';
 import { Injectable } from '@nestjs/common';
 import { DataSource, EntityManager } from 'typeorm';
-import { withSlaveConnection } from '@us-epa-camd/easey-common';
+import { withSlaveConnection, withMasterConnection } from '@us-epa-camd/easey-common';
 
 import { EmissionsViewDTO } from '../dto/emissions-view.dto';
 import { EmissionsViewParamsDTO } from '../dto/emissions-view.params.dto';
@@ -68,7 +68,7 @@ export class EmissionsViewService {
 
       if (rpCounts && rpCounts.length === 0) {
         promises.push(
-          withSlaveConnection(this.dataSource, async (entityManager: EntityManager) => {
+          withMasterConnection(this.dataSource, async (entityManager: EntityManager) => {
             await entityManager.query(
               `CALL camdecmps.refresh_emission_view_${viewCode}($1, $2);`,
               [params.monitorPlanId, rp.id],


### PR DESCRIPTION
## Ticket
[Global View: Unable to view EM data](https://github.com/US-EPA-CAMD/easey-ui/issues/7028)

## Changes
The `refresh_emission_view_{viewCode}` stored procedure must be executed using a master database connection because it performs write operations (DELETE and INSERT) that cannot run in a read-only transaction.


>Note: I am unable to test this change in my local environment.