### PR TITLE
Revert/6980 sampling train undefined access

### DIFF
--- a/src/dto/sorbent-trap.dto.ts
+++ b/src/dto/sorbent-trap.dto.ts
@@ -103,8 +103,7 @@ export class SorbentTrapImportDTO extends SorbentTrapBaseDTO {
   @Type(() => SamplingTrainImportDTO)
   @ArrayMinSize(2)
   @ArrayMaxSize(2)
-  @IsOptional()
-  samplingTrainData?: SamplingTrainImportDTO[];
+  samplingTrainData: SamplingTrainImportDTO[];
 }
 
 export class SorbentTrapDTO extends SorbentTrapRecordDTO {


### PR DESCRIPTION
## Related Issues:

- https://github.com/US-EPA-CAMD/easey-ui/issues/6980

## Main Changes:

- The ECMPS 1.0 schema was reviewed and it was found that `samplingTrainData` should, in fact, be required.