### PR TITLE
remove master connection and getSelectedView slave connection

### DIFF
--- a/src/emission-view/emissions-view.service.ts
+++ b/src/emission-view/emissions-view.service.ts
@@ -1,7 +1,7 @@
 import { Request } from 'express';
 import { Injectable } from '@nestjs/common';
 import { DataSource, EntityManager } from 'typeorm';
-import { withSlaveConnection, withMasterConnection } from '@us-epa-camd/easey-common';
+import { withSlaveConnection } from '@us-epa-camd/easey-common';
 
 import { EmissionsViewDTO } from '../dto/emissions-view.dto';
 import { EmissionsViewParamsDTO } from '../dto/emissions-view.params.dto';

--- a/src/emission-view/emissions-view.service.ts
+++ b/src/emission-view/emissions-view.service.ts
@@ -13,7 +13,8 @@ export class EmissionsViewService {
   constructor(
     private readonly dataSource: DataSource,
     private readonly repository: EmissionsViewRepository,
-  ) {}
+    private readonly entityManager: EntityManager,
+  ) { }
 
   async getAvailableViews(): Promise<EmissionsViewDTO[]> {
     return withSlaveConnection(this.dataSource, async (entityManager: EntityManager) => {
@@ -68,12 +69,11 @@ export class EmissionsViewService {
 
       if (rpCounts && rpCounts.length === 0) {
         promises.push(
-          withMasterConnection(this.dataSource, async (entityManager: EntityManager) => {
-            await entityManager.query(
-              `CALL camdecmps.refresh_emission_view_${viewCode}($1, $2);`,
-              [params.monitorPlanId, rp.id],
-            );
-          })
+          this.repository.query(
+            `
+            CALL camdecmps.refresh_emission_view_${viewCode}($1, $2);`,
+            [params.monitorPlanId, rp.id],
+          ),
         );
       }
     });
@@ -82,15 +82,13 @@ export class EmissionsViewService {
       await Promise.all(promises);
     }
 
-    return withSlaveConnection(this.dataSource, async (entityManager: EntityManager) => {
-      return getSelectedView(
-        viewCode,
-        'camdecmps',
-        req,
-        params,
-        rptPeriods,
-        entityManager,
-      );
-    });
+    return getSelectedView(
+      viewCode,
+      'camdecmps',
+      req,
+      params,
+      rptPeriods,
+      this.entityManager,
+    );
   }
 }


### PR DESCRIPTION
## Ticket 
[Global View: Unable to view EM data](https://github.com/US-EPA-CAMD/easey-ui/issues/7028)
## Change

- Remove `withMasterConnection` and call the refresh procedure directly, since master is already the default.
- Remove the final `withSlaveConnection` so that getSelectedView runs against master and returns the freshly refreshed emissions data.