### PR TITLE
Fix/7043 emissions refresh timeout

### DIFF
--- a/src/emission-view/emissions-view.service.ts
+++ b/src/emission-view/emissions-view.service.ts
@@ -64,7 +64,7 @@ export class EmissionsViewService {
     const promises = [];
     rptPeriods.forEach(async (rp: { id: number }) => {
       let rpCounts = counts.filter(c => {
-        return c.rptPeriodId === Number(rp.id) && c.dataSetCode == viewCode;
+        return Number(c.rptPeriodId) === Number(rp.id) && c.dataSetCode == viewCode;
       });
 
       if (rpCounts && rpCounts.length === 0) {

--- a/src/emissions-view-workspace/emission-view-service.spec.ts
+++ b/src/emissions-view-workspace/emission-view-service.spec.ts
@@ -8,19 +8,24 @@ import * as selectedEmissionView from '../utils/selected-emission-view';
 
 describe('EmissionsViewService', () => {
   let service: EmissionsViewWorkspaceService;
+  let repository: EmissionsViewWorkspaceRepository;
   let req: any;
   let params = new EmissionsViewParamsDTO();
 
+  const mockEntityManager = {
+    query: jest.fn().mockResolvedValue([]),
+  };
+
   const mockRepository = {
     find: jest.fn(),
-    query: jest.fn(),
+    query: jest.fn().mockResolvedValue([]),
   };
 
   beforeEach(async () => {
     const module: TestingModule = await Test.createTestingModule({
       providers: [
         EmissionsViewWorkspaceService,
-        EntityManager,
+        { provide: EntityManager, useValue: mockEntityManager },
         {
           provide: EmissionsViewWorkspaceRepository,
           useValue: mockRepository,
@@ -29,6 +34,7 @@ describe('EmissionsViewService', () => {
     }).compile();
 
     service = module.get(EmissionsViewWorkspaceService);
+    repository = module.get(EmissionsViewWorkspaceRepository);
   });
 
   it('should be defined', () => {
@@ -39,6 +45,7 @@ describe('EmissionsViewService', () => {
     const mockSelectedView = jest
       .spyOn(selectedEmissionView, 'getSelectedView')
       .mockResolvedValue(null);
+
     const result = await service.getView('dailyCal', req, params);
     expect(result).toEqual(null);
     expect(mockSelectedView).toHaveBeenCalled();

--- a/src/emissions-view-workspace/emissions-view.service.ts
+++ b/src/emissions-view-workspace/emissions-view.service.ts
@@ -33,13 +33,45 @@ export class EmissionsViewWorkspaceService {
     req: Request,
     params: EmissionsViewParamsDTO,
   ) {
-    const rptPeriods = await this.repository.query(
-      `
-      SELECT rpt_period_id as id
-      FROM camdecmpsmd.reporting_period
-      WHERE period_abbreviation = ANY($1);`,
-      [params.reportingPeriod],
-    );
+      const rptPeriods = await this.entityManager.query(
+        `SELECT rpt_period_id as id
+         FROM camdecmpsmd.reporting_period
+         WHERE period_abbreviation = ANY($1);`,
+        [params.reportingPeriod],
+      );
+
+      const counts = await getSelectedView(
+        'COUNTS',
+        'camdecmpswks',
+        req,
+        params,
+        rptPeriods,
+        this.entityManager,
+      );
+
+    if (viewCode === 'COUNTS') return counts;
+
+    const promises = [];
+    rptPeriods.forEach(async (rp: { id: number }) => {
+      let rpCounts = counts.filter(c => {
+        return c.rptPeriodId === Number(rp.id) && c.dataSetCode == viewCode;
+      });
+
+      if (rpCounts && rpCounts.length === 0) {
+        promises.push(
+          this.repository.query(
+            `
+            CALL camdecmpswks.refresh_emission_view_${viewCode}($1, $2);`,
+            [params.monitorPlanId, rp.id],
+          ),
+        );
+      }
+    });
+
+    if (promises.length > 0) {
+      await Promise.all(promises);
+    }
+
     return getSelectedView(
       viewCode,
       'camdecmpswks',

--- a/src/emissions-view-workspace/emissions-view.service.ts
+++ b/src/emissions-view-workspace/emissions-view.service.ts
@@ -54,7 +54,7 @@ export class EmissionsViewWorkspaceService {
     const promises = [];
     rptPeriods.forEach(async (rp: { id: number }) => {
       let rpCounts = counts.filter(c => {
-        return c.rptPeriodId === Number(rp.id) && c.dataSetCode == viewCode;
+        return Number(c.rptPeriodId) === Number(rp.id) && c.dataSetCode == viewCode;
       });
 
       if (rpCounts && rpCounts.length === 0) {

--- a/src/emissions-workspace/emissions.repository.spec.ts
+++ b/src/emissions-workspace/emissions.repository.spec.ts
@@ -42,11 +42,4 @@ describe('Emisions Workspace Repository Test', () => {
       expect(result).toEqual(mockedResult);
     });
   });
-
-  describe('updateAllViews', () => {
-    it('successfully calls updateAllViews()', async () => {
-      await repository.updateAllViews();
-      expect(repository.query).toHaveBeenCalled();
-    });
-  });
 });

--- a/src/emissions-workspace/emissions.repository.ts
+++ b/src/emissions-workspace/emissions.repository.ts
@@ -26,12 +26,4 @@ export class EmissionsWorkspaceRepository extends Repository<
       .andWhere('rp.quarter = :quarter', { quarter });
     return query.getOne();
   }
-
-  async updateAllViews(monitorPlanId: string, quarter: number, year: number) {
-    await this.query('CALL camdecmpswks.refresh_emissions_views($1,$2,$3)', [
-      monitorPlanId,
-      year,
-      quarter,
-    ]);
-  }
 }

--- a/src/emissions-workspace/emissions.service.ts
+++ b/src/emissions-workspace/emissions.service.ts
@@ -319,26 +319,24 @@ export class EmissionsWorkspaceService {
           }),
         );
 
-        await repository.updateAllViews(
-          monitorPlanId,
-          params.quarter,
-          params.year,
-        );
+        // Delete existing emission view counts for this monitor plan and reporting period
+        await trx.query('DELETE FROM camdecmpswks.emission_view_count where mon_plan_id = $1 and rpt_period_id = $2', 
+          [monitorPlanId, reportingPeriodId]);
 
         // Finally, perform the updates (reset needs eval flag, etc) for those records
         await this.updateCollaterallyAffectedRecords(monitorPlanId, reportingPeriodId, trx);
 
         await queryRunner.commitTransaction();
-
-        return {
-          message: `Successfully Imported Emissions Data for Facility Id/Oris Code [${params.orisCode}]`,
-        };
       } catch (err) {
         await queryRunner.rollbackTransaction();
         throw err;
       } finally {
         await queryRunner.release();
       }
+
+      return {
+        message: `Successfully Imported Emissions Data for Facility Id/Oris Code [${params.orisCode}]`,
+      };
     }
 
   async updateCollaterallyAffectedRecords(monitorPlanId: string, reportingPeriodId: number, trx?: EntityManager): Promise<void> {

--- a/test/mocks/emissions-workspace-repository.ts
+++ b/test/mocks/emissions-workspace-repository.ts
@@ -2,7 +2,6 @@ export const mockEmissionsWorkspaceRepository = {
   create: () => undefined,
   delete: jest.fn().mockResolvedValue(undefined),
   export: () => jest,
-  updateAllViews: () => jest,
   findOne: () => undefined,
   save: jest.fn().mockResolvedValue(undefined),
   query: jest.fn().mockResolvedValue(['']),


### PR DESCRIPTION
## Related Issues:

- https://github.com/US-EPA-CAMD/easey-ui/issues/7043
- https://github.com/US-EPA-CAMD/easey-ui/issues/7086

## Main Changes:

- Remove the call to `camdecmpswks.refresh_emissions_views` at the end of the import process. Instead, simply reset the emissions view row counts, and refresh individual views when retrieving the view data.